### PR TITLE
bugfix: banner-text z-index conflict

### DIFF
--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -25,6 +25,7 @@ section h2 {
   min-height: 30vh;
   position: relative;
   overflow: hidden;
+  /* prevents .banner-text from overlapping with primary-nav dropdown on wide viewport widts */
   isolation: isolate;
 }
 


### PR DESCRIPTION
Fixes a conflict between the CSS `z-index` on the primary navigation and banner text that prevented the primary nav dropdowns from being hoverable and clickable.