### PR TITLE
update 11ty image plugin config widths and sizes

### DIFF
--- a/eleventy.config.images.js
+++ b/eleventy.config.images.js
@@ -22,8 +22,8 @@ function pluginImages(eleventyConfig) {
       const input = path.join(__dirname, "public", "img", filename);
 
       const metadata = await eleventyImage(input, {
-        widths: [...widths, null], // null means the original size
-        formats: [...formats, null], // null means the original format
+        widths,
+        formats,
         // Advanced usage note: `eleventyConfig.dir` works here because we’re using addPlugin.
         outputDir: path.join(eleventyConfig.dir.output, "img"),
         outputPath: "/img/",


### PR DESCRIPTION
Forgot to do this in #40:

Updates the 11ty image plugin config to remove original img size & formats as currently not using the original image size or format so no need to keep them when creating responsive images. Can always add this back later.