### PR TITLE
bugfix: sitemap.xml lastmod date

### DIFF
--- a/content/sitemap.xml.njk
+++ b/content/sitemap.xml.njk
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
     {%- set absoluteUrl %}{{ slugified | htmlBaseUrl(metadata.url) }}{% endset %}
     <url>
       <loc>{{ absoluteUrl }}</loc>
-      <lastmod>{{ project.date | dateFromISOString }}</lastmod>
+      <lastmod>{{ project.date }}</lastmod>
     </url>
   {%- endfor %}
 </urlset>


### PR DESCRIPTION
For project pages in `/work/[project-name]/`, use `project.date` as is, since it's already a valid `lastmod` date format.