### PR TITLE
update form radio & checkbox focus styles

### DIFF
--- a/assets/css/components/forms/form-controls.css
+++ b/assets/css/components/forms/form-controls.css
@@ -30,11 +30,6 @@ input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="r
   box-shadow: var(--focus-style-box-shadow);
 }
 
-input[type="checkbox"]:focus,
-input[type="radio"]:focus {
-  outline: none;
-}
-
 /* class applied to a div that wraps an input and label */
 .form-control {
   display: flex;
@@ -53,8 +48,22 @@ input[type="radio"]:focus {
   margin-bottom: var(--spacing-xs);
 }
 
-.form-control:focus-within {
-  box-shadow: var(--focus-style-box-shadow);
+.form-control input[type="checkbox"]:focus,
+.form-control input[type="radio"]:focus {
+  outline: var(--focus-style-outline);
+}
+
+@supports (selector(:focus-visible)) and (selector(:has(a))) {
+  .form-control input[type="checkbox"]:focus,
+  .form-control input[type="radio"]:focus {
+    outline: none;
+  }
+
+  /* :focus-visible-within hack credit: https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class */
+  .form-control:has(:focus-visible) {
+    outline: var(--focus-style-outline);
+    outline-offset: var(--focus-style-outline-offset);
+  }
 }
 
 .form-control > label {

--- a/assets/css/components/forms/form-controls.css
+++ b/assets/css/components/forms/form-controls.css
@@ -6,12 +6,12 @@ label {
 fieldset {
   padding: 0 var(--spacing-md);
   margin: 0 var(--spacing-xs) var(--spacing-md) var(--spacing-xs);
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
 }
 
 textarea,
-input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"]) {
-  border: solid .1em currentColor;
+input:not([type="checkbox"], [type="file"], [type="image"], [type="radio"], [type="range"]) {
+  border: solid .1em currentcolor;
   border-radius: var(--border-radius);
   background-color: var(--background-color-secondary);
   padding: var(--spacing-xs);
@@ -19,13 +19,13 @@ input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="r
 }
 
 textarea::placeholder,
-input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"])::placeholder {
+input:not([type="checkbox"], [type="file"], [type="image"], [type="radio"], [type="range"])::placeholder {
   opacity: 0.8;
   color: inherit;
 }
 
 textarea:focus,
-input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"]):focus {
+input:not([type="checkbox"], [type="file"], [type="image"], [type="radio"], [type="range"]):focus {
   outline: 0.15em solid var(--color-accent);
   box-shadow: var(--focus-style-box-shadow);
 }


### PR DESCRIPTION
Adds the [`:focus-visible-within` css technique](https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class) to the default `.form-control` class for styling focus indicators on checkbox and radio button inputs.