### PR TITLE
bugfix: page titles a11y

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -1,6 +1,9 @@
 {# Sitewide head element used in all pages #}
-{%- set headTitleBase = title or metadata.title %}
-{%- set headTitle = [headTitleBase, metadata.author.name].join(" – ") %}
+{%- set headTitleBase = title or metadata.author.name %}
+{%- set headTitle =
+  headTitleBase if headTitleBase.includes(metadata.author.name)
+  else [headTitleBase, metadata.author.name].join(" – ")
+-%}
 {%- set headDescription = teaser or description or metadata.description %}
 {%- set headImageAlt = imageAlt or metadata.titleImageAlt %}
 {%- set headImageType = imageType or metadata.titleImageType %}

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -1,5 +1,6 @@
 {# Sitewide head element used in all pages #}
-{%- set headTitle = title or metadata.title %}
+{%- set headTitleBase = title or metadata.title %}
+{%- set headTitle = [headTitleBase, metadata.author.name].join(" – ") %}
 {%- set headDescription = teaser or description or metadata.description %}
 {%- set headImageAlt = imageAlt or metadata.titleImageAlt %}
 {%- set headImageType = imageType or metadata.titleImageType %}

--- a/content/index.njk
+++ b/content/index.njk
@@ -2,6 +2,8 @@
 layout: layouts/home.njk
 numberOfLatestPostsToShow: 3
 pageSize: fullwidth
+eleventyComputed:
+  title: Home
 ---
 
 {%- set partials %}

--- a/content/tags-list.njk
+++ b/content/tags-list.njk
@@ -1,8 +1,9 @@
 ---
 permalink: /tags/
 layout: layouts/home.njk
+title: "All Blog Tags"
 ---
-<h1>Tags</h1>
+<h1>{{title}}</h1>
 
 <ul>
 {% for tag in collections.all | getAllTags | filterTagList %}

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -1,4 +1,5 @@
 ---
+title: "Portfolio"
 eleventyNavigation:
   key: Work
   order: 2

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -6,6 +6,7 @@ pagination:
 permalink: "work/{{ project.title | slugify }}/"
 tags: projects
 eleventyComputed:
+  title: "{{ project.title }}, Portfolio"
   eleventyNavigation:
     key: "{{ project.title }}"
     parent: "work"

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -4,7 +4,6 @@ pagination:
   size: 1
   alias: project
 permalink: "work/{{ project.title | slugify }}/"
-tags: projects
 eleventyComputed:
   title: "{{ project.title }}, Portfolio"
   eleventyNavigation:


### PR DESCRIPTION
Addresses #55 by making sure each page has a unique `<title>` that is also useful out of context.