### PR TITLE
focus style updates

### DIFF
--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -126,6 +126,12 @@ html {
   overflow-y: scroll;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
 body {
   font-family: var(--font-family);
   font-size: var(--text-size-md);

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -178,13 +178,25 @@ h5 {
 }
 
 /* sets focus style on jump link fragments */
-h2[id]:focus,
-h3[id]:focus,
-h4[id]:focus,
-h5[id]:focus {
-  outline: var(--focus-style-outline);
-  outline-offset: var(--focus-style-outline-offset);
-  border-radius: var(--border-radius);
+h2[id]:target,
+h3[id]:target,
+h4[id]:target,
+h5[id]:target {
+  color: var(--color-accent-invert);
+  background-color: var(--color-accent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  h2[id]:target,
+  h3[id]:target,
+  h4[id]:target,
+  h5[id]:target {
+    transition: background-color 1s ease-in-out;
+
+    @starting-style {
+      background-color: transparent;
+    }
+  }
 }
 
 h1 {

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -252,7 +252,7 @@ small {
 
 :where(a[href]:hover, a[href]:focus) {
   color: var(--color-accent-focus);
-  outline: none;
+  outline: transparent;
   text-decoration-thickness: 0.5rem;
   text-decoration-skip-ink: none;
 }

--- a/assets/css/components/forms/form-controls.css
+++ b/assets/css/components/forms/form-controls.css
@@ -56,7 +56,7 @@ input:not([type="checkbox"], [type="file"], [type="image"], [type="radio"], [typ
 @supports (selector(:focus-visible)) and (selector(:has(a))) {
   .form-control input[type="checkbox"]:focus,
   .form-control input[type="radio"]:focus {
-    outline: none;
+    outline: transparent;
   }
 
   /* :focus-visible-within hack credit: https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class */

--- a/assets/css/components/forms/select.css
+++ b/assets/css/components/forms/select.css
@@ -65,8 +65,8 @@ select::-ms-expand {
   }
 
   .select-menu:has(:focus-visible) {
-    outline: 0.15em solid var(--color-accent);
-    box-shadow: var(--focus-style-box-shadow);
+    outline: 3px solid var(--background-color);
+    box-shadow: var(--focus-style-button-box-shadow);
   }
 }
 

--- a/assets/css/components/forms/select.css
+++ b/assets/css/components/forms/select.css
@@ -18,9 +18,11 @@ select {
 
   /* Stack above custom arrow */
   z-index: 1;
+}
 
-  /* NOTE: focus added via .select-menu:focus-within */
-  outline: none;
+select:focus {
+  /* NOTE: overridden further below if :has and :focus-visible selectors are supported */
+  outline: var(--focus-style-outline);
 }
 
 /* Remove dropdown arrow in IE10 & IE11 */
@@ -57,9 +59,15 @@ select::-ms-expand {
   clip-path: polygon(100% 0%, 0 0%, 50% 100%);
 }
 
-.select-menu:focus-within {
-  outline: 0.15em solid var(--color-accent);
-  box-shadow: var(--focus-style-box-shadow);
+@supports (selector(:focus-visible)) and (selector(:has(a))) {
+  select:focus {
+    outline: transparent;
+  }
+
+  .select-menu:has(:focus-visible) {
+    outline: 0.15em solid var(--color-accent);
+    box-shadow: var(--focus-style-box-shadow);
+  }
 }
 
 .select-menu--disabled {

--- a/assets/css/components/project-card.css
+++ b/assets/css/components/project-card.css
@@ -61,9 +61,14 @@
   border: 1px solid;
   border-radius: var(--border-radius);
   cursor: pointer;
-  transition:
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card {
+    transition:
     border ease-in .2s,
     box-shadow ease-in .2s;
+  }
 }
 
 .card[hidden] {

--- a/assets/css/components/project-card.css
+++ b/assets/css/components/project-card.css
@@ -98,7 +98,7 @@
 
 .card:focus-within a[href]:focus {
   text-decoration: none;
-  outline: none;
+  outline: transparent;
   box-shadow: none;
 }
 

--- a/assets/css/components/theme-toggle.css
+++ b/assets/css/components/theme-toggle.css
@@ -33,7 +33,7 @@
 
 @supports (selector(:focus-visible)) and (selector(:has(a))) {
   #site-theme-toggle input[type="radio"]:focus {
-    outline: none;
+    outline: transparent;
   }
 
   /* :focus-visible-within hack credit: https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class */

--- a/assets/css/components/theme-toggle.css
+++ b/assets/css/components/theme-toggle.css
@@ -13,6 +13,11 @@
   border: none;
 }
 
+#site-theme-toggle:target {
+  outline: 5px solid var(--color-accent);
+  outline-offset: var(--focus-style-outline-offset);
+}
+
 #site-theme-toggle span {
   font-weight: bold;
 }

--- a/assets/css/components/theme-toggle.css
+++ b/assets/css/components/theme-toggle.css
@@ -18,6 +18,15 @@
   outline-offset: var(--focus-style-outline-offset);
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  #site-theme-toggle:target {
+    transition: outline 3s ease-in-out;
+    @starting-style {
+      outline: transparent;
+    }
+  }
+}
+
 #site-theme-toggle span {
   font-weight: bold;
 }

--- a/assets/css/layouts/footer.css
+++ b/assets/css/layouts/footer.css
@@ -53,8 +53,8 @@ footer a[href]:hover {
 }
 
 footer a[href]:focus-visible {
-  box-shadow: var(--focus-style-box-shadow);
   outline: var(--focus-style-outline);
+  outline-offset: var(--focus-style-outline-offset);
   text-decoration: none;
 }
 

--- a/assets/css/layouts/header.css
+++ b/assets/css/layouts/header.css
@@ -37,7 +37,7 @@ header.page-header {
 
 .page-header a[href]:focus-visible,
 .page-header button.nav-button:focus-visible {
-  outline: none;
+  outline: transparent;
   box-shadow: inset var(--focus-style-box-shadow);
 }
 

--- a/content/blog/2024-07-14-eleventy-migration-and-redesign.md
+++ b/content/blog/2024-07-14-eleventy-migration-and-redesign.md
@@ -12,8 +12,8 @@ tags:
 ---
 
 <style>
-  #site-theme-toggle:focus {
-    outline: var(--focus-style-outline);
+  #site-theme-toggle:target {
+    outline: 5px solid var(--color-accent);
     outline-offset: var(--focus-style-outline-offset);
   }
 </style>

--- a/content/blog/2024-07-14-eleventy-migration-and-redesign.md
+++ b/content/blog/2024-07-14-eleventy-migration-and-redesign.md
@@ -11,13 +11,6 @@ tags:
   - Design
 ---
 
-<style>
-  #site-theme-toggle:target {
-    outline: 5px solid var(--color-accent);
-    outline-offset: var(--focus-style-outline-offset);
-  }
-</style>
-
 ## Introduction
 
 Earlier this year I began migrating this website, [{{ metadata.title }}]({{ metadata.url }}), from [Jekyll](https://jekyllrb.com/) to [Eleventy (11ty)](https://www.11ty.dev/). There were a bunch of underlying factors that pushed me to do the migration, which I'll discuss in this post. Unlike other posts I've previously written, I won't really dive into the technical aspects of the process (okay let's be real, there will obviously still be some technical details included here), this will be more about the "why" then the "how". The migration presented an opportunity for redesigning some pieces of the site which I'll also touch on here.

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -98,7 +98,8 @@ eleventyComputed:
   <a href="/work/">
     <span aria-hidden="true" class="back-arrow">&#8619;</span> Go back to the Portfolio
   </a>
-  <a href="#main" aria-label="Go back to top of page">
+  <a href="#main" aria-labelledby="back-top">
+    <span id="back-top" hidden>Go back to top of page</span>
     <span aria-hidden="true">&#8679;</span>
   </a>
 </nav>


### PR DESCRIPTION
- use `outline: transparent` instead of `outline: none` for focus states to support high contrast mode
- use `:target` instead of `:focus` for styling fragments in jump links
- bonus: use `scroll-behavior: smooth` when permissible
- update footer link focus styles to use `outline` instead of `box-shadow` to give link text some breathing room.