### PR TITLE
bugfix: code syntax highlighting color contrast

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -3,7 +3,7 @@ layout: layouts/base.njk
 ---
 {# TODO: add a11y-light.css and adjust for light & dark themes #}
 {%- set partials %}
-  node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css,
+  prism/a11y-dark.css,
   components/forms/form-controls,
   components/forms/select,
   pages/post

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -1,8 +1,9 @@
 ---
 layout: layouts/base.njk
 ---
+{# TODO: add a11y-light.css and adjust for light & dark themes #}
 {%- set partials %}
-  node_modules/prismjs/themes/prism-okaidia.css,
+  node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css,
   components/forms/form-controls,
   components/forms/select,
   pages/post

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -3,7 +3,7 @@ layout: layouts/base.njk
 ---
 {# TODO: add a11y-light.css and adjust for light & dark themes #}
 {%- set partials %}
-  prism/a11y-dark.css,
+  node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css,
   components/forms/form-controls,
   components/forms/select,
   pages/post

--- a/assets/css/pages/post.css
+++ b/assets/css/pages/post.css
@@ -21,6 +21,18 @@ pre[class*="language-"] {
   font-size: 1rem;
 }
 
+pre[class*="language-"][tabindex="0"]:focus-visible {
+  outline: var(--focus-style-outline);
+  outline-offset: var(--focus-style-width);
+}
+
+@supports not selector(:focus-visible) {
+  pre[class*="language-"][tabindex="0"]:focus {
+    outline: var(--focus-style-outline);
+    outline-offset: var(--focus-style-width);
+  }
+}
+
 dl.post-metadata dd {
   font-weight: bold;
 }

--- a/content/blog/2022-01-31-color-legend-element.md
+++ b/content/blog/2022-01-31-color-legend-element.md
@@ -29,11 +29,13 @@ I recently [open sourced and launched](https://twitter.com/chrislhenrick/status/
 
 An important part of creating the CLE for me was making it simple to use. You can read more about its usage in the links mentioned above, but the gist of it is:
 
-1. include the script tag
-2. declare the HTML
+1. Include the script tag
+2. Declare the HTML
 
 ```html
-<script src="https://unpkg.com/color-legend-element@1.0.3/build/color-legend-element.umd.js"></script>
+<script
+  src="https://unpkg.com/color-legend-element@1.0.3/build/color-legend-element.umd.js"
+></script>
 
 <color-legend
   titletext="Temperature (°C)"
@@ -179,13 +181,16 @@ One thing that's interesting to note about slotted elements is that they are con
 color-legend p {
   margin: 0.5rem 0;
 }
+
 color-legend small {
   font-size: 0.75rem;
 }
+
 p.no-data {
   display: inline-flex;
   align-items: center;
 }
+
 p.no-data:before {
   content: "";
   width: 0.75rem;

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -49,9 +49,6 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addPassthroughCopy(
       "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css"
     );
-    eleventyConfig.addPassthroughCopy(
-      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css"
-    );
   }
 
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -46,12 +46,12 @@ module.exports = function (eleventyConfig) {
   if (process.env.NODE_ENV !== "production") {
     eleventyConfig.addPassthroughCopy("assets/js");
     eleventyConfig.addPassthroughCopy("assets/css");
-    eleventyConfig.addPassthroughCopy({
-      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css":
-        "assets/css/prism/ally-dark.css",
-      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css":
-        "assets/css/prism/a11y-light.css",
-    });
+    eleventyConfig.addPassthroughCopy(
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css"
+    );
+    eleventyConfig.addPassthroughCopy(
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css"
+    );
   }
 
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -47,7 +47,8 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addPassthroughCopy("assets/js");
     eleventyConfig.addPassthroughCopy("assets/css");
     eleventyConfig.addPassthroughCopy(
-      "node_modules/prismjs/themes/prism-okaidia.css"
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css",
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css",
     );
   }
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -46,10 +46,12 @@ module.exports = function (eleventyConfig) {
   if (process.env.NODE_ENV !== "production") {
     eleventyConfig.addPassthroughCopy("assets/js");
     eleventyConfig.addPassthroughCopy("assets/css");
-    eleventyConfig.addPassthroughCopy(
-      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css",
-      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css",
-    );
+    eleventyConfig.addPassthroughCopy({
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-dark.css":
+        "assets/css/prism/ally-dark.css",
+      "node_modules/a11y-syntax-highlighting/dist/prism/a11y-light.css":
+        "assets/css/prism/a11y-light.css",
+    });
   }
 
   eleventyConfig.addPlugin(EleventyHtmlBasePlugin);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@11ty/eleventy-plugin-bundle": "^1.0.5",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
+    "a11y-syntax-highlighting": "^0.2.0",
     "luxon": "^3.4.4",
     "markdown-it": "^14.1.0",
     "netlify-plugin-cache": "^1.0.3",


### PR DESCRIPTION
Addresses #53:

Use [Eric Bailey's a11y color contrast theme for PrismJS](https://github.com/ericwbailey/a11y-syntax-highlighting/) to fix the poor color contrast of code blocks in blog posts.