### PR TITLE
typography style updates: apply text-wrap and oklch p3 colors when supported

### DIFF
--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -70,6 +70,19 @@
   --focus-style-button-box-shadow: 0 0 0 6px var(--color-accent);
 }
 
+@supports(oklch(from orange)) {
+  @media (color-gamut: p3) {
+    :root {
+      --color-orange: oklch(from var(--color-orange) l calc(c + 0.03) h);
+      --color-orange-2: oklch(from var(--color-orange-2) l calc(c + 0.02) h);
+      --color-orange-3: oklch(from var(--color-orange-3) l calc(c + 0.035) h);
+      --color-blue: oklch(from var(--color-blue) l calc(c + 0.03) h);
+      --color-blue-2: oklch(from var(--color-blue-2) l calc(c + 0.02) h);
+      --color-blue-3: oklch(from var(--color-blue-3) l calc(c + 0.015) h);
+    }
+  }
+}
+
 @media screen and (min-width: 46.75rem) {
   :root {
     --main-nav-height: 4.375rem;

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -70,8 +70,9 @@
   --focus-style-button-box-shadow: 0 0 0 6px var(--color-accent);
 }
 
-@supports(oklch(from orange)) {
-  @media (color-gamut: p3) {
+/* modify color palette for richer colors when p3 is available */
+@media (dynamic-range: high) {
+  @supports(background: oklch(from orange l c h)) {
     :root {
       --color-orange: oklch(from var(--color-orange) l calc(c + 0.03) h);
       --color-orange-2: oklch(from var(--color-orange-2) l calc(c + 0.02) h);

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -27,6 +27,7 @@
   --color-turquoise-dark: #334D5C;
   --color-turquoise-light: #45b29d;
 
+  --text-color-link: var(--color-accent);
   --text-color-link-active: var(--color-accent-secondary);
   --text-color-link-visited: var(--color-accent-secondary);
 
@@ -87,7 +88,9 @@
   --background-color: var(--color-off-white);
   --background-color-secondary: var(--color-off-white-3);
   --text-color: var(--color-gray-90);
-  --text-color-link: var(--color-accent);
+  --text-color-link: var(--color-accent-secondary);
+  --text-color-link-active: var(--color-accent);
+  --text-color-link-visited: var(--color-accent);
 }
 
 :root[data-theme="dark"] {
@@ -101,6 +104,9 @@
   --background-color: #222;
   --background-color-secondary: #1e1810;
   --text-color: var(--color-gray-10);
+  --text-color-link: var(--color-accent-secondary);
+  --text-color-link-active: var(--color-accent);
+  --text-color-link-visited: var(--color-accent);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -182,6 +182,11 @@ main:focus-visible {
   }
 }
 
+*::selection {
+  color: var(--color-accent-invert);
+  background-color: var(--color-accent);
+}
+
 h1,
 h2,
 h3,

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -190,6 +190,7 @@ h5 {
   margin-top: var(--spacing-lg);
   margin-bottom: var(--spacing-md);
   line-height: var(--line-height-heading);
+  text-wrap: balance;
 }
 
 /* sets focus style on jump link fragments */
@@ -244,6 +245,7 @@ h5 {
 p {
   max-width: 77ch;
   margin-bottom: var(--spacing-mmd);
+  text-wrap: pretty;
 }
 
 p:last-child {

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -74,15 +74,15 @@
 @media (dynamic-range: high) {
   @supports(background: oklch(from orange l c h)) {
     :root {
-      --color-orange: oklch(from #e68933 l calc(c + 0.03) h);
+      --color-orange: oklch(from #e68933 l calc(c + 0.04) h);
       --color-orange-2: oklch(from #ffa047 l calc(c + 0.02) h);
-      --color-orange-3: oklch(from #efc94c l calc(c + 0.035) h);
+      --color-orange-3: oklch(from #efc94c l 0.18 h);
       --color-blue: oklch(from #00529d l calc(c + 0.03) h);
-      --color-blue-2: oklch(from #013e76 l calc(c + 0.02) h);
-      --color-blue-3: oklch(from #012445 l calc(c + 0.015) h);
-      --color-turquoise: oklch(from #307b6c l 0.13 h);
-      --color-turquoise-dark: oklch(from #334D5C l 0.09 h);
-      --color-turquoise-light: oklch(from #45b29d l 0.09 h);
+      --color-blue-2: oklch(from #013e76 l calc(c + 0.03) h);
+      --color-blue-3: oklch(from #012445 l calc(c + 0.02) h);
+      --color-turquoise: oklch(from #307b6c l 0.2 h);
+      --color-turquoise-dark: oklch(from #334D5C l 0.1 h);
+      --color-turquoise-light: oklch(from #45b29d l 0.15 h);
     }
   }
 }

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -88,9 +88,6 @@
   --background-color: var(--color-off-white);
   --background-color-secondary: var(--color-off-white-3);
   --text-color: var(--color-gray-90);
-  --text-color-link: var(--color-accent-secondary);
-  --text-color-link-active: var(--color-accent);
-  --text-color-link-visited: var(--color-accent);
 }
 
 :root[data-theme="dark"] {
@@ -122,6 +119,9 @@
     --background-color: #222;
     --background-color-secondary: #1e1810;
     --text-color: var(--color-gray-10);
+    --text-color-link: var(--color-accent-secondary);
+    --text-color-link-active: var(--color-accent);
+    --text-color-link-visited: var(--color-accent);
   }
 }
 

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -80,6 +80,9 @@
       --color-blue: oklch(from var(--color-blue) l calc(c + 0.03) h);
       --color-blue-2: oklch(from var(--color-blue-2) l calc(c + 0.02) h);
       --color-blue-3: oklch(from var(--color-blue-3) l calc(c + 0.015) h);
+      --color-turquoise: oklch(from var(--color-turquoise) l 0.13 h);
+      --color-turquoise-dark: oklch(from var(--color-turquoise-dark) l 0.09 h);
+      --color-turquoise-light: oklch(from var(--color-turquoise-light) l 0.09 h);
     }
   }
 }

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -74,15 +74,15 @@
 @media (dynamic-range: high) {
   @supports(background: oklch(from orange l c h)) {
     :root {
-      --color-orange: oklch(from var(--color-orange) l calc(c + 0.03) h);
-      --color-orange-2: oklch(from var(--color-orange-2) l calc(c + 0.02) h);
-      --color-orange-3: oklch(from var(--color-orange-3) l calc(c + 0.035) h);
-      --color-blue: oklch(from var(--color-blue) l calc(c + 0.03) h);
-      --color-blue-2: oklch(from var(--color-blue-2) l calc(c + 0.02) h);
-      --color-blue-3: oklch(from var(--color-blue-3) l calc(c + 0.015) h);
-      --color-turquoise: oklch(from var(--color-turquoise) l 0.13 h);
-      --color-turquoise-dark: oklch(from var(--color-turquoise-dark) l 0.09 h);
-      --color-turquoise-light: oklch(from var(--color-turquoise-light) l 0.09 h);
+      --color-orange: oklch(from #e68933 l calc(c + 0.03) h);
+      --color-orange-2: oklch(from #ffa047 l calc(c + 0.02) h);
+      --color-orange-3: oklch(from #efc94c l calc(c + 0.035) h);
+      --color-blue: oklch(from #00529d l calc(c + 0.03) h);
+      --color-blue-2: oklch(from #013e76 l calc(c + 0.02) h);
+      --color-blue-3: oklch(from #012445 l calc(c + 0.015) h);
+      --color-turquoise: oklch(from #307b6c l 0.13 h);
+      --color-turquoise-dark: oklch(from #334D5C l 0.09 h);
+      --color-turquoise-light: oklch(from #45b29d l 0.09 h);
     }
   }
 }

--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -290,31 +290,6 @@ small {
   text-decoration-skip-ink: none;
 }
 
-pre,
-code {
-  font-family: var(--font-family-monospace);
-}
-
-pre:not([class*="language-"]) {
-  margin: 0.5em 0;
-  line-height: 1.375; /* 22px /16 */
-  -moz-tab-size: var(--syntax-tab-size);
-  -o-tab-size: var(--syntax-tab-size);
-  tab-size: var(--syntax-tab-size);
-  -webkit-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-}
-
-code {
-  word-break: break-word;
-}
-
 dl > div {
   display: flex;
   align-items: baseline;

--- a/assets/css/components/code.css
+++ b/assets/css/components/code.css
@@ -67,6 +67,11 @@
   }
 }
 
+pre,
+code {
+  font-family: var(--font-family-monospace);
+}
+
 /*
  Theme
  */
@@ -74,9 +79,9 @@ code[class*="language-"],
 pre[class*="language-"] {
   color: var(--color-syntax-1);
   background: none;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
   font-size: 1rem;
   text-align: left;
+  direction: ltr;
   white-space: pre;
   word-spacing: normal;
   word-break: normal;

--- a/assets/css/layouts/header.css
+++ b/assets/css/layouts/header.css
@@ -20,14 +20,15 @@ header.page-header {
   }
 }
 
+.page-header a[href],
+.page-header a[href]:visited {
+  color: var(--color-accent);
+}
+
 .page-header a[href] {
   padding: var(--spacing-sm) var(--spacing-mmd);
   display: inline-block;
   text-decoration: none;
-}
-
-.page-header a[href]:visited {
-  color: var(--text-color-link);
 }
 
 .page-header a[href]:hover {

--- a/assets/css/layouts/header.css
+++ b/assets/css/layouts/header.css
@@ -132,7 +132,7 @@ button.nav-button {
   gap: 0.25rem;
   padding: 0.5rem 0.75rem;
   font-weight: normal;
-  color: var(--text-color-link);
+  color: var(--color-accent);
   background-color: transparent;
 }
 

--- a/assets/css/pages/post.css
+++ b/assets/css/pages/post.css
@@ -43,4 +43,5 @@ main p:has(picture) {
 p.post-teaser {
   font-size: var(--text-size-h4);
   font-style: italic;
+  text-wrap: balance;
 }

--- a/assets/css/pages/work.css
+++ b/assets/css/pages/work.css
@@ -29,12 +29,19 @@ main p:first-of-type {
 }
 
 @media (prefers-color-scheme: dark) {
-  .js-enabled .project-filters {
+  :root:not([data-theme]) .js-enabled .project-filters {
     --button-bg-pressed:var(--color-turquoise);
     --button-bg: var(--color-turquoise-light);
     --button-text-color: var(--color-gray-90);
     --button-text-color-pressed: var(--color-white);
   }
+}
+
+:root[data-theme="dark"] .js-enabled .project-filters {
+  --button-bg-pressed:var(--color-turquoise);
+  --button-bg: var(--color-turquoise-light);
+  --button-text-color: var(--color-gray-90);
+  --button-text-color-pressed: var(--color-white);
 }
 
 .project-filters button.button {


### PR DESCRIPTION
- consolidate code block type styles from `base.css` to `code.css`
- use `text-wrap` `balance` and `pretty` where appropriate
- add `::selection` style for all text elements
- reverse link styling for regular and `:visited` links in dark theme
- fixes project filter button colors in light theme
- BONUS: add some p3 colors via oklch for accent colors when supported