### PR TITLE
blog pagination ui enhancements

### DIFF
--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -35,12 +35,14 @@
 
 .button:focus-visible {
   outline: 3px solid var(--background-color);
+  outline-offset: 0;
   box-shadow: var(--focus-style-button-box-shadow);
 }
 
 @supports not selector(:focus-visible) {
   .button:focus {
     outline: 3px solid var(--background-color);
+    outline-offset: 0;
     box-shadow: var(--focus-style-button-box-shadow);
   }
 }

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -50,8 +50,8 @@ nav.pagination li:nth-child(-n+2) {
 
 nav.pagination li a[href][aria-current="page"] {
   background-color: var(--color-accent-secondary);
-  outline: 2.5px dotted var(--background-color);
-  outline-offset: -5px;
+  outline: var(--focus-style-width) dotted var(--background-color);
+  outline-offset: calc(-2 * var(--focus-style-width));
 }
 
 nav.pagination li a[href][aria-current="page"]:hover {

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -1,4 +1,5 @@
 nav.pagination {
+  --min-list-item-width: 65px;
   margin-top: var(--spacing-xxxl);
 }
 
@@ -8,11 +9,14 @@ nav.pagination > h2 {
 }
 
 nav.pagination > ol {
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, [col] minmax(var(--min-list-item-width), 1fr));
+  grid-gap: 8px;
   margin-bottom: 1.5rem;
 }
 
-nav.pagination li a[href] {
+nav.pagination li a {
+  width: 100%;
   padding: 0.75rem var(--spacing-mmd);
 }
 
@@ -24,8 +28,9 @@ nav.pagination li a:not([href]) {
   cursor: initial;
 }
 
-nav.pagination li a[href].previous-next {
-  min-width: 140px;
+/* previous and next links */
+nav.pagination li:nth-child(-n+2) {
+  grid-column: span 2;
 }
 
 nav.pagination li a[href][aria-current="page"] {

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -30,6 +30,8 @@ nav.pagination li a[href].previous-next {
 
 nav.pagination li a[href][aria-current="page"] {
   background-color: var(--color-accent-secondary);
+  outline: 2.5px dotted var(--background-color);
+  outline-offset: -5px;
 }
 
 nav.pagination li a[href][aria-current="page"]:hover {

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -12,18 +12,18 @@ nav.pagination > ol {
   display: grid;
   /* narrow of narrowest viewports: stacks prev, next links on separate rows, numbered links two in a row */
   grid-template-columns: repeat(auto, [col] minmax(var(--min-list-item-width), 1fr));
-  grid-gap: 8px;
+  grid-gap: var(--spacing-sm);
   margin-bottom: 1.5rem;
 }
 
-@media screen and (width >= 332px) {
+@media screen and (width >= 345px) {
   nav.pagination > ol {
     /* moderately narrow viewports: prev, next links side by side same row, numbered links four in a row below */
     grid-template-columns: repeat(4, [col] minmax(var(--min-list-item-width), 1fr));
   }
 }
 
-@media screen and (width >= 478px) {
+@media screen and (width >= 500px) {
   nav.pagination > ol {
     /* everything else / wider viewports: auto-fit all links in one row, overflowing to more rows if needed */
     grid-template-columns: repeat(auto-fit, [col] minmax(var(--min-list-item-width), 1fr));

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -15,3 +15,15 @@ nav.pagination > ol {
 nav.pagination li a[href] {
   padding: 0.75rem var(--spacing-mmd);
 }
+
+/* disabled previous and next links */
+nav.pagination li a:not([href]) {
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border-color: var(--color-accent);
+  cursor: initial;
+}
+
+nav.pagination li a[href].previous-next {
+  min-width: 140px;
+}

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -10,9 +10,21 @@ nav.pagination > h2 {
 
 nav.pagination > ol {
   display: grid;
-  grid-template-columns: repeat(auto-fill, [col] minmax(var(--min-list-item-width), 1fr));
+  grid-template-columns: repeat(auto, [col] minmax(var(--min-list-item-width), 1fr));
   grid-gap: 8px;
   margin-bottom: 1.5rem;
+}
+
+@media screen and (width >= 332px) {
+  nav.pagination > ol {
+    grid-template-columns: repeat(4, [col] minmax(var(--min-list-item-width), 1fr));
+  }
+}
+
+@media screen and (width >= 478px) {
+  nav.pagination > ol {
+    grid-template-columns: repeat(auto-fill, [col] minmax(var(--min-list-item-width), 1fr));
+  }
 }
 
 nav.pagination li a {

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -27,3 +27,13 @@ nav.pagination li a:not([href]) {
 nav.pagination li a[href].previous-next {
   min-width: 140px;
 }
+
+nav.pagination li a[href][aria-current="page"] {
+  background-color: var(--color-accent-secondary);
+}
+
+nav.pagination li a[href][aria-current="page"]:hover {
+  background-color: var(--color-accent-secondary);
+  border-color: transparent;
+  color: var(--color-accent-invert);
+}

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -60,7 +60,7 @@ nav.pagination li a[href][aria-current="page"]:hover {
   color: var(--color-accent-invert);
 }
 
-/* reset focus outline style */
+/* reset focus indicator outline style to match that of .button */
 nav.pagination li a[href][aria-current="page"]:focus-visible {
   outline: 3px solid var(--background-color);
   outline-offset: 0;

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -10,6 +10,7 @@ nav.pagination > h2 {
 
 nav.pagination > ol {
   display: grid;
+  /* narrow of narrowest viewports: stacks prev, next links on separate rows, numbered links two in a row */
   grid-template-columns: repeat(auto, [col] minmax(var(--min-list-item-width), 1fr));
   grid-gap: 8px;
   margin-bottom: 1.5rem;
@@ -17,13 +18,15 @@ nav.pagination > ol {
 
 @media screen and (width >= 332px) {
   nav.pagination > ol {
+    /* moderately narrow viewports: prev, next links side by side same row, numbered links four in a row below */
     grid-template-columns: repeat(4, [col] minmax(var(--min-list-item-width), 1fr));
   }
 }
 
 @media screen and (width >= 478px) {
   nav.pagination > ol {
-    grid-template-columns: repeat(auto-fill, [col] minmax(var(--min-list-item-width), 1fr));
+    /* everything else / wider viewports: auto-fit all links in one row, overflowing to more rows if needed */
+    grid-template-columns: repeat(auto-fit, [col] minmax(var(--min-list-item-width), 1fr));
   }
 }
 

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -13,19 +13,19 @@ nav.pagination > ol {
   /* narrow of narrowest viewports: stacks prev, next links on separate rows, numbered links two in a row */
   grid-template-columns: repeat(auto, [col] minmax(var(--min-list-item-width), 1fr));
   grid-gap: var(--spacing-sm);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-mmd);
 }
 
 @media screen and (width >= 345px) {
   nav.pagination > ol {
-    /* moderately narrow viewports: prev, next links side by side same row, numbered links four in a row below */
+    /* moderately narrow viewports: prev, next links side by side on the same row, numbered links four in a row below */
     grid-template-columns: repeat(4, [col] minmax(var(--min-list-item-width), 1fr));
   }
 }
 
 @media screen and (width >= 500px) {
   nav.pagination > ol {
-    /* everything else / wider viewports: auto-fit all links in one row, overflowing to more rows if needed */
+    /* everything else / wider viewports: auto-fit all links in one row, overflowing to more rows as needed */
     grid-template-columns: repeat(auto-fit, [col] minmax(var(--min-list-item-width), 1fr));
   }
 }

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -56,3 +56,16 @@ nav.pagination li a[href][aria-current="page"]:hover {
   border-color: transparent;
   color: var(--color-accent-invert);
 }
+
+/* reset focus outline style */
+nav.pagination li a[href][aria-current="page"]:focus-visible {
+  outline: 3px solid var(--background-color);
+  outline-offset: 0;
+}
+
+@supports not selector(:focus-visible) {
+  nav.pagination li a[href][aria-current="page"]:focus {
+    outline: 3px solid var(--background-color);
+    outline-offset: 0;
+  }
+}

--- a/assets/css/pages/blog.css
+++ b/assets/css/pages/blog.css
@@ -11,7 +11,7 @@ nav.pagination > h2 {
 nav.pagination > ol {
   display: grid;
   /* narrow of narrowest viewports: stacks prev, next links on separate rows, numbered links two in a row */
-  grid-template-columns: repeat(auto, [col] minmax(var(--min-list-item-width), 1fr));
+  grid-template-columns: repeat(auto, minmax(var(--min-list-item-width), 1fr));
   grid-gap: var(--spacing-sm);
   margin-bottom: var(--spacing-mmd);
 }
@@ -19,14 +19,14 @@ nav.pagination > ol {
 @media screen and (width >= 345px) {
   nav.pagination > ol {
     /* moderately narrow viewports: prev, next links side by side on the same row, numbered links four in a row below */
-    grid-template-columns: repeat(4, [col] minmax(var(--min-list-item-width), 1fr));
+    grid-template-columns: repeat(4, minmax(var(--min-list-item-width), 1fr));
   }
 }
 
 @media screen and (width >= 500px) {
   nav.pagination > ol {
     /* everything else / wider viewports: auto-fit all links in one row, overflowing to more rows as needed */
-    grid-template-columns: repeat(auto-fit, [col] minmax(var(--min-list-item-width), 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(var(--min-list-item-width), 1fr));
   }
 }
 

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -29,6 +29,7 @@ pagination:
 <nav class="pagination" aria-labelledby="pagination-title">
   <span id="pagination-title" hidden>Pagination</span>
   <ol role="list" class="inline">
+    {# NOTE: previous and next links are first to aid keyboard navigation (why tab through all the links to get to "next"?) #}
     {# previous page #}
     <li>
       <a

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -60,5 +60,7 @@ pagination:
     </li>
 {%- endfor %}
   </ol>
-  <a class="button" href="/blog/archive/">Blog Archive</a>
+  <p>
+    You may view all posts in the <a href="/blog/archive/">Blog Archive</a>.
+  </p>
 </nav>

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -29,7 +29,26 @@ pagination:
 <nav class="pagination" aria-labelledby="pagination">
   <span id="pagination" hidden>Pagination</span>
   <ol role="list" class="inline">
-    <li>{% if pagination.href.previous %}<a class="button" rel="prev" href="{{ pagination.href.previous }}">Previous</a>{% else %}Previous{% endif %}</li>
+    {# previous page #}
+    <li>
+      <a
+        class="button previous-next"
+        rel="prev"
+        {%- if pagination.href.previous %}href="{{ pagination.href.previous }}"{% endif %}
+      >
+        Previous
+      </a>
+    </li>
+    {# next page #}
+    <li>
+      <a
+        class="button previous-next"
+        rel="next"
+        {%- if pagination.href.next %}href="{{ pagination.href.next }}"{% endif %}
+      >
+        Next
+      </a>
+    </li>
 {%- for pageEntry in pagination.pages %}
     <li><a class="button" href="{{ pagination.hrefs[ loop.index0 ] }}"{% if page.url == pagination.hrefs[ loop.index0 ] %} aria-current="page"{% endif %}>{{ loop.index }}</a></li>
 {%- endfor %}

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -55,7 +55,8 @@ pagination:
         class="button"
         href="{{ pagination.hrefs[ loop.index0 ] }}"
         {% if page.url == pagination.hrefs[ loop.index0 ] %} aria-current="page"{% endif %}
-      >{{ loop.index }}
+      >
+        <span class="visually-hidden">Page</span> {{ loop.index }}
       </a>
     </li>
 {%- endfor %}

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -26,8 +26,8 @@ pagination:
 {% set postslist = posts | reverse %}
 {% include "postslist.njk" %}
 
-<nav class="pagination" aria-labelledby="pagination">
-  <span id="pagination" hidden>Pagination</span>
+<nav class="pagination" aria-labelledby="pagination-title">
+  <span id="pagination-title" hidden>Pagination</span>
   <ol role="list" class="inline">
     {# previous page #}
     <li>
@@ -50,9 +50,15 @@ pagination:
       </a>
     </li>
 {%- for pageEntry in pagination.pages %}
-    <li><a class="button" href="{{ pagination.hrefs[ loop.index0 ] }}"{% if page.url == pagination.hrefs[ loop.index0 ] %} aria-current="page"{% endif %}>{{ loop.index }}</a></li>
+    <li>
+      <a
+        class="button"
+        href="{{ pagination.hrefs[ loop.index0 ] }}"
+        {% if page.url == pagination.hrefs[ loop.index0 ] %} aria-current="page"{% endif %}
+      >{{ loop.index }}
+      </a>
+    </li>
 {%- endfor %}
-    <li>{% if pagination.href.next %}<a class="button" rel="next" href="{{ pagination.href.next }}">Next</a>{% else %}Next{% endif %}</li>
   </ol>
   <a class="button" href="/blog/archive/">Blog Archive</a>
 </nav>


### PR DESCRIPTION
Addresses issue #10

---

**Bonus:** improves responsive design of the pagination links:

Widest viewports:

<img width="776" alt="Screenshot 2024-08-12 at 6 12 25 PM" src="https://github.com/user-attachments/assets/bc493fd6-e3e1-4c27-bbeb-a16364f23e96">

Narrower:

<img width="498" alt="Screenshot 2024-08-12 at 6 12 39 PM" src="https://github.com/user-attachments/assets/3a5d6650-39a8-4908-a937-01ac234cd3f2">

More narrow:

<img width="473" alt="Screenshot 2024-08-12 at 6 13 23 PM" src="https://github.com/user-attachments/assets/78f89d3f-cd5e-4d8e-8076-fd1209ae8e1b">

Narrowest:

<img width="320" alt="Screenshot 2024-08-12 at 6 13 38 PM" src="https://github.com/user-attachments/assets/b5cf090c-e26f-4edb-a2ff-a12e0a0dd93c">

---

Bonus: resets `.button`'s `outline-offset` style to zero (Chrome appears to use a 1px default value). Prevents this from happening:

<img width="204" alt="image" src="https://github.com/user-attachments/assets/609e8a8e-1518-486a-805b-dc76f7bb3e2a">
