### PR TITLE
bugfix: ko-fi link

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 eleventyComputed:
-  kofiUrl: metadata.get("Ko-Fi")
+  kofiUrl: "{{ metadata.social.get('Ko-Fi') }}"
 ---
 {%- set partials %}
   components/code,
@@ -16,7 +16,6 @@ eleventyComputed:
 {% from "components/kofi.njk" import kofi %}
 
 <article aria-describedby="post-title">
-
   <h1 id="post-title">{{ title }}</h1>
 
   {%- if teaser %}

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -6,7 +6,7 @@ pagination:
 permalink: "work/{{ project.title | slugify }}/"
 eleventyComputed:
   title: "{{ project.title }}, Portfolio"
-  kofiUrl: metadata.get("Ko-Fi")
+  kofiUrl: "{{ metadata.social.get('Ko-Fi') }}"
   eleventyNavigation:
     key: "{{ project.title }}"
     parent: "work"


### PR DESCRIPTION
Fixes usage of 11ty computed data in blog post and project pages templates that gets passed to the ko-fi macro.