### PR TITLE
Add mastodon author tag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
   },
   "[nunjucks]": {
     "editor.wordWrapColumn": 100,
-    "editor.wordWrap": "bounded"
+    "editor.wordWrap": "bounded",
+    "editor.formatOnSave": false
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/_data/README.md
+++ b/_data/README.md
@@ -25,7 +25,7 @@ The current NodeJS enivornment may be referenced from here, e.g.:
 Social media names and their corresponding URLs are available via an ES6 Map which can be iterated via Nunjucks `for` (see `footer.njk`) or used to retrieve a single URL, e.g.
 
 ```js
-metadata.social.get("Mastodon");
+metadata.socialLinks.get("Mastodon");
 // returns "https://indieweb.social/@clhenrick"
 ```
 

--- a/_data/README.md
+++ b/_data/README.md
@@ -22,7 +22,7 @@ The current NodeJS environment may be referenced from here, e.g.:
 {% endif %}
 ```
 
-Various media and their corresponding URLs are available via `socialLinks`, an ES6 Map which can be iterated via Nunjucks `for` (see `footer.njk`) or used to retrieve a single URL, e.g.
+Various social media and their corresponding URLs are available via `socialLinks`, an ES6 Map which can be iterated via Nunjucks `for` (see `footer.njk`) or used to retrieve a single URL, e.g.
 
 ```js
 metadata.socialLinks.get("Mastodon");

--- a/_data/README.md
+++ b/_data/README.md
@@ -12,7 +12,7 @@ Image widths arrays and sizes strings used with the Eleventy Image Plugin and it
 
 Global site metadata including the site's `title`, `description`, `url`, `language`, etc.
 
-The current NodeJS enivornment may be referenced from here, e.g.:
+The current NodeJS environment may be referenced from here, e.g.:
 
 ```nunjucks
 {% if metadata.environment === "production" %}
@@ -22,11 +22,18 @@ The current NodeJS enivornment may be referenced from here, e.g.:
 {% endif %}
 ```
 
-Social media names and their corresponding URLs are available via an ES6 Map which can be iterated via Nunjucks `for` (see `footer.njk`) or used to retrieve a single URL, e.g.
+Various media and their corresponding URLs are available via `socialLinks`, an ES6 Map which can be iterated via Nunjucks `for` (see `footer.njk`) or used to retrieve a single URL, e.g.
 
 ```js
 metadata.socialLinks.get("Mastodon");
 // returns "https://indieweb.social/@clhenrick"
+```
+
+The `socialHandles` Map is similar but returns just the handle for a social media:
+
+```js
+metadata.socialHandles.get("Mastodon");
+// returns "@clhenrick@indieweb.social
 ```
 
 ## work_image_thumbnails/

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -24,7 +24,7 @@ module.exports = {
     ["LinkedIn", "@chrishenrick"],
     ["Ko-Fi", "@chrislhenrick"],
   ]),
-  social: new Map([
+  socialLinks: new Map([
     ["GitHub", "https://github.com/clhenrick"],
     ["Mastodon", "https://indieweb.social/@clhenrick"],
     ["X (Twitter)", "https://twitter.com/chrislhenrick"],

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,12 +1,14 @@
 module.exports = {
   title: "clhenrick.io",
   titleImage: "img/oakland-map-dark-1800w.webp",
-  titleImageAlt: "A geographic map of the city of Oakland, California, centered on Lake Merritt.",
+  titleImageAlt:
+    "A geographic map of the city of Oakland, California, centered on Lake Merritt.",
   titleImageType: "image/webp",
   logoImage: "favicon/apple-touch-icon.png",
   url: "https://clhenrick.io/",
   language: "en",
-  description: "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",
+  description:
+    "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",
   environment: process.env.NODE_ENV,
   githubRepository: "https://github.com/clhenrick/clhenrick.io",
   author: {
@@ -14,12 +16,20 @@ module.exports = {
     email: "chrishenrick@gmail.com",
     url: "https://clhenrick.io/about/",
   },
+  socialHandles: new Map([
+    ["Github", "@clhenrick"],
+    ["Mastodon", "@clhenrick@indieweb.social"],
+    ["X (Twitter)", "@chrislhenrick"],
+    ["Observable", "@clhenrick"],
+    ["LinkedIn", "@chrishenrick"],
+    ["Ko-Fi", "@chrislhenrick"],
+  ]),
   social: new Map([
     ["GitHub", "https://github.com/clhenrick"],
     ["Mastodon", "https://indieweb.social/@clhenrick"],
     ["X (Twitter)", "https://twitter.com/chrislhenrick"],
     ["Observable", "https://observablehq.com/@clhenrick"],
     ["LinkedIn", "https://www.linkedin.com/in/chrishenrick/"],
-    ["Ko-Fi", "https://ko-fi.com/chrislhenrick"]
+    ["Ko-Fi", "https://ko-fi.com/chrislhenrick"],
   ]),
 };

--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -40,7 +40,7 @@
     <section>
       <h2>Social Links</h2>
       <ul class="social-links" role="list">
-      {%- for name, url in metadata.social %}
+      {%- for name, url in metadata.socialLinks %}
         <li>
           <a href={{url}} {% if name == "Mastodon" %} rel="me" {% endif %} >{{name}}</a>
         </li>

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -37,6 +37,9 @@
   <meta name="google-site-verification" content="hb0oFgJAnd2i2LvJYSEIofF5sc24xc8hx2tTNittvHA">
   <meta name="msvalidate.01" content="2515EC227874C1EE104D3FB4124CC9C5">
 
+  {# Fediverse author tags #}
+  <meta name="fediverse:creator" content="{{ metadata.socialHandles.get('Mastodon') }}">
+
   {# Social: Open Graph tags #}
   <meta property="og:locale" content="en_US">
   <meta property="og:title" content="{{ headTitle }}">

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 eleventyComputed:
-  kofiUrl: "{{ metadata.social.get('Ko-Fi') }}"
+  kofiUrl: "{{ metadata.socialLinks.get('Ko-Fi') }}"
 ---
 {%- set partials %}
   components/code,

--- a/content/blog/2024-07-14-eleventy-migration-and-redesign.md
+++ b/content/blog/2024-07-14-eleventy-migration-and-redesign.md
@@ -55,4 +55,4 @@ One deliberate decision that relates to this was to throw out Google Fonts and i
 
 ## Phew!
 
-So there you have it. This site is now built with Eleventy. It aims to be more inclusive and accessible, to use fewer digital resources, yet still be a unique place that represents who I am (professionally at least) online. I hope you appreciate it. If you have any thoughts, questions, suggestions, or comments please don't hesitate to [contact me](/contact/). I'm also active on [Mastodon]({{metadata.social.get("Mastodon")}}) if you would like to reach or follow me there. Thanks for reading!
+So there you have it. This site is now built with Eleventy. It aims to be more inclusive and accessible, to use fewer digital resources, yet still be a unique place that represents who I am (professionally at least) online. I hope you appreciate it. If you have any thoughts, questions, suggestions, or comments please don't hesitate to [contact me](/contact/). I'm also active on [Mastodon](<{{metadata.socialLinks.get("Mastodon")}}>) if you would like to reach or follow me there. Thanks for reading!

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -6,7 +6,7 @@ pagination:
 permalink: "work/{{ project.title | slugify }}/"
 eleventyComputed:
   title: "{{ project.title }}, Portfolio"
-  kofiUrl: "{{ metadata.social.get('Ko-Fi') }}"
+  kofiUrl: "{{ metadata.socialLinks.get('Ko-Fi') }}"
   eleventyNavigation:
     key: "{{ project.title }}"
     parent: "work"


### PR DESCRIPTION
Reference article: https://rknight.me/blog/setting-up-mastodon-author-tags/
- adds new `metadata.socialHandles`
- renames `metadata.social` to `metadata.socialLinks`
- adds `<meta>` tag for mastodon author tag
- disables vs code save on format for njk files (it was breaking things when comments got split to multiple lines)
