### PR TITLE
minor form element updates

### DIFF
--- a/_includes/components/themeToggle.njk
+++ b/_includes/components/themeToggle.njk
@@ -2,11 +2,11 @@
 {%- set themes = ["light", "dark", "auto"]  -%}
 <fieldset
   id="site-theme-toggle"
-  aria-labelledby="site-theme-toggle-label"
   tabindex="-1"
 >
   {# NOTE: we use a span here because <legend> doesn't play well with `display: flex` on the fieldset parent #}
-  <span id="site-theme-toggle-label">Site Theme:</span>
+  <legend class="visually-hidden">Site Theme:</legend>
+  <span aria-hidden="true">Site Theme:</span>
   {%- for theme in themes %}
     {%- set id = ["site-theme", theme] | join("-") %}
     <div class="form-control">

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -39,6 +39,7 @@ eleventyNavigation:
       name="name"
       id="full-name"
       required=""
+      autocomplete="name"
     >
     <p class="form-error-msg" id="full-name-error-msg" hidden></p>
   </div>
@@ -50,6 +51,8 @@ eleventyNavigation:
       name="_replyto"
       id="email-address"
       required=""
+      autocomplete="on"
+      inputmode="email"
     >
     <p class="form-error-msg" id="email-address-error-msg" hidden></p>
   </div>
@@ -62,6 +65,7 @@ eleventyNavigation:
       id="message"
       required=""
       minlength="120"
+      autocomplete="off"
     ></textarea>
     <p class="form-error-msg" id="note-error-msg" hidden></p>
   </div>

--- a/content/search/index.njk
+++ b/content/search/index.njk
@@ -44,6 +44,7 @@ eleventyNavigation:
     id="search-text"
     name="q"
     type="text"
+    autocomplete="off"
     {# NOTE: tried adding an <input type="hidden"> with the "site:name" value, but DDG seems to only keep the last "q" query param value, so it gets replaced by the users search query. #}
     value="{{ searchPrefix }} "
     required=""


### PR DESCRIPTION
Addresses remainder of #81 

Contact form:

- added sensible `autocomplete` attr values to form fields
- added `inputmode="email"` to email input for improved virtual keyboard

Search form:

- disable autocomplete in search input

Theme toggle:

*note: this technique has more consistent browser support for giving a fieldset an accName while having more flexible control over the position of the visual label*
- use visually hidden `<legend>` element for accName
- apply `aria-hidden="true"` to visual `<span>`