### PR TITLE
contact form error msg updates

### DIFF
--- a/assets/js/contact-form.js
+++ b/assets/js/contact-form.js
@@ -142,17 +142,18 @@
     }
 
     // client side form validation errors
-    if (Array.isArray(errors) && errors.length) {
-      const pluralHandler = errors.length > 1 ? "s" : "";
-      const fieldTypes = errors
-        .map((element) => (element.type === "email" ? "email" : element.name))
-        .join(" and ");
-      errorMessage = `Please correct the error${pluralHandler} in the ${fieldTypes} form field${pluralHandler}.`;
-    }
-
-    // if an empty array is passed from a result of no form fields with aria-invalid="true", truncate the errorMessage as to reset the form status to empty
-    if (!errors?.length) {
-      errorMessage = "";
+    if (Array.isArray(errors)) {
+      if (errors.length) {
+        const pluralHandler = errors.length > 1 ? "s" : "";
+        const fieldTypes = errors
+          .map((element) => (element.type === "email" ? "email" : element.name))
+          .join(" and ");
+        errorMessage = `Please correct the error${pluralHandler} in the ${fieldTypes} form field${pluralHandler}.`;
+      } else {
+        // if an empty array is passed from a result of no form fields with `aria-invalid="true"`,
+        // truncate the errorMessage as to reset the form status to empty
+        errorMessage = "";
+      }
     }
 
     if (errorMessage) {

--- a/assets/js/contact-form.js
+++ b/assets/js/contact-form.js
@@ -128,7 +128,7 @@
 
   /**
    * - handles a client or server side form validation error
-   * @param {(HTMLInputElement | HTMLTextAreaElement)[] | string} errors either a string of error text that should be shown or an array of form fields that are in an invalid state.
+   * @param {(HTMLInputElement | HTMLTextAreaElement)[] | string} errors either a string of error text that should be shown or an array of form fields that are in an invalid state. Note that the array is permitted to be empty.
    * @param {boolean} shouldFocus whether to focus the form status field after updating its text content; defaults to true
    */
   function handleInvalidFormState(errors, shouldFocus = true) {
@@ -150,12 +150,11 @@
       errorMessage = `Please correct the error${pluralHandler} in the ${fieldTypes} form field${pluralHandler}.`;
     }
 
-    // if an empty array is passed from a result of no [aria-invalid="true"], truncate the errorMessage as to reset the form status to empty
+    // if an empty array is passed from a result of no form fields with aria-invalid="true", truncate the errorMessage as to reset the form status to empty
     if (!errors?.length) {
       errorMessage = "";
     }
 
-    // for any error situation
     if (errorMessage) {
       formStatus.innerText = errorMessage;
       formStatus.classList = "error";

--- a/assets/js/contact-form.js
+++ b/assets/js/contact-form.js
@@ -128,9 +128,10 @@
 
   /**
    * - handles a client or server side form validation error
-   * @param {(HTMLInputElement | HTMLTextAreaElement)[] | string} [errors] either a string of error text that should be shown or an array of form fields that are in an invalid state.
+   * @param {(HTMLInputElement | HTMLTextAreaElement)[] | string} errors either a string of error text that should be shown or an array of form fields that are in an invalid state.
+   * @param {boolean} shouldFocus whether to focus the form status field after updating its text content; defaults to true
    */
-  function handleInvalidFormState(errors) {
+  function handleInvalidFormState(errors, shouldFocus = true) {
     // default error message
     let errorMessage =
       "Something went wrong when submitting the form. Please try submitting the form again or alternatively you may send me an email. Thanks!";
@@ -149,11 +150,22 @@
       errorMessage = `Please correct the error${pluralHandler} in the ${fieldTypes} form field${pluralHandler}.`;
     }
 
+    // if an empty array is passed from a result of no [aria-invalid="true"], truncate the errorMessage as to reset the form status to empty
+    if (!errors?.length) {
+      errorMessage = "";
+    }
+
     // for any error situation
-    formStatus.innerText = errorMessage;
-    formStatus.classList = "error";
-    formStatus.removeAttribute("hidden");
-    formStatus.focus();
+    if (errorMessage) {
+      formStatus.innerText = errorMessage;
+      formStatus.classList = "error";
+      formStatus.removeAttribute("hidden");
+      shouldFocus && formStatus.focus();
+    } else {
+      formStatus.innerText = "";
+      formStatus.classList = "";
+      formStatus.setAttribute("hidden", "");
+    }
   }
 
   function handleFormSubmitSuccess() {
@@ -266,5 +278,9 @@
       // since disabled buttons aren't the best for a11y (poor color contrast,
       // removed from tab order, etc).
     }
+
+    // update the form status message
+    const invalidFormFields = getInvalidFormFields();
+    handleInvalidFormState(Array.from(invalidFormFields), false);
   }
 })();

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -34,6 +34,7 @@ eleventyNavigation:
 
   <div class="form-control-group">
     <label for="full-name">Your Name (required)</label>
+    <p class="form-error-msg" id="full-name-error-msg" hidden></p>
     <input
       type="text"
       name="name"
@@ -41,11 +42,11 @@ eleventyNavigation:
       required=""
       autocomplete="name"
     >
-    <p class="form-error-msg" id="full-name-error-msg" hidden></p>
   </div>
 
   <div class="form-control-group">
     <label for="email-address">Your Email Address (required)</label>
+    <p class="form-error-msg" id="email-address-error-msg" hidden></p>
     <input
       type="email"
       name="_replyto"
@@ -54,11 +55,11 @@ eleventyNavigation:
       autocomplete="on"
       inputmode="email"
     >
-    <p class="form-error-msg" id="email-address-error-msg" hidden></p>
   </div>
 
   <div class="form-control-group">
     <label for="message">Your Message (required)</label>
+    <p class="form-error-msg" id="note-error-msg" hidden></p>
     <textarea
       rows="5"
       name="message"
@@ -67,7 +68,6 @@ eleventyNavigation:
       minlength="120"
       autocomplete="off"
     ></textarea>
-    <p class="form-error-msg" id="note-error-msg" hidden></p>
   </div>
 
   <input

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -27,6 +27,7 @@ eleventyNavigation:
   action="https://formspree.io/f/xoqgkgyk"
   method="post"
   aria-labelledby="form-title"
+  aria-describedby="form-status"
 >
   <span id="form-title" hidden>Contact Chris Henrick</span>
 


### PR DESCRIPTION
- Move error messages above inputs so that they won't be obscured by autocomplete or virtual keyboard.
- Update form status message on form blur events to prevent status message from indicating there is an error with a form field when the error has been fixed.

References:
- https://adrianroselli.com/2017/01/avoid-messages-under-fields.html
- https://web-a11y.slack.com/archives/C071U5Y3H/p1731682509843889