### PR TITLE
update prettier to format nunjucks files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 public
 _data/work_image_thumbnails
 _includes/components/blog-posts/color-experiments-oklch/lineChart*.njk
+content/feed/json.njk

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ _site
 node_modules
 public
 _data/work_image_thumbnails
+_includes/components/blog-posts/color-experiments-oklch/lineChart*.njk

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,12 @@
-trailingComma: "es5"
+{
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-jinja-template"],
+  "overrides": [
+    {
+      "files": ["*.njk"],
+      "options": {
+        "parser": "jinja-template"
+      }
+    }
+  ]
+}

--- a/_includes/components/blog-posts/color-experiments-oklch/colorSwatch.njk
+++ b/_includes/components/blog-posts/color-experiments-oklch/colorSwatch.njk
@@ -4,8 +4,20 @@
   {% set height = height or 50 %}
   <svg viewBox="0 0 {{ width }} {{ height }}" role="img">
     <title>The color swatch {{ color }} in CSS notation</title>
-    <rect x="0" y="0" width="{{ width }}" height="{{ height }}" fill="{{ color }}" />
-    <text x="100" y="30" text-anchor="middle" fill="{{ textColor }}" {% if not showText %}hidden{% endif %}>
+    <rect
+      x="0"
+      y="0"
+      width="{{ width }}"
+      height="{{ height }}"
+      fill="{{ color }}"
+    />
+    <text
+      x="100"
+      y="30"
+      text-anchor="middle"
+      fill="{{ textColor }}"
+      {% if not showText %}hidden{% endif %}
+    >
       {{ color }}
     </text>
   </svg>

--- a/_includes/components/blog-posts/color-experiments-oklch/colorSwatchFigure.njk
+++ b/_includes/components/blog-posts/color-experiments-oklch/colorSwatchFigure.njk
@@ -1,14 +1,14 @@
 {% from "./colorSwatch.njk" import colorSwatch %}
 
 {%- macro colorSwatchFigure(swatches = [], caption = "", showText = true) %}
-<figure class="swatch-container">
-  <div>
-    {%- for swatch in swatches %}
-    {{ colorSwatch(swatch.fill, swatch.textFill, showText, swatch.width, swatch.height) }}
-    {%- endfor %}
-  </div>
-  {% if (caption) %}
-  <figcaption>{{ caption }}</figcaption>
-  {% endif %}
-</figure>
+  <figure class="swatch-container">
+    <div>
+      {%- for swatch in swatches %}
+        {{ colorSwatch(swatch.fill, swatch.textFill, showText, swatch.width, swatch.height) }}
+      {%- endfor %}
+    </div>
+    {% if (caption) %}
+      <figcaption>{{ caption }}</figcaption>
+    {% endif %}
+  </figure>
 {%- endmacro %}

--- a/_includes/components/kofi.njk
+++ b/_includes/components/kofi.njk
@@ -3,11 +3,13 @@
 {% macro kofi(url, item = "post") %}
   <article class="kofi" aria-labelledby="kofi-title">
     <span id="kofi-title" hidden>Donate</span>
-    <p>No generative AI or LLMs were used for creating any part of this website.</p>
     <p>
-    So, if you enjoyed this {{ item }}, please feel free to
-    <a href={{url}}>buy me a coffee</a>!
-    <span class="kofi-emoji" aria-hidden="true">☕️</span>
+      No generative AI or LLMs were used for creating any part of this website.
+    </p>
+    <p>
+      So, if you enjoyed this {{ item }}, please feel free to
+      <a href="{{ url }}">buy me a coffee</a>!
+      <span class="kofi-emoji" aria-hidden="true">☕️</span>
     </p>
   </article>
 {% endmacro %}

--- a/_includes/components/navListItem.njk
+++ b/_includes/components/navListItem.njk
@@ -1,18 +1,18 @@
 {# renders a nav list item for the primary / top-level desktop navigation #}
 {%- macro renderNavListItem(entry, pageUrl) %}
-<li class="nav-item">
-  <a
-    href="{{ entry.url }}"
-    {%- if entry.url == pageUrl %} aria-current="page"{% endif %}
-  >
-  {{- entry.title -}}
-  </a>
-  {%- if entry.children.length %}
-    <ul role="list" class="with-dropdown">
-      {%- for child in entry.children %}
-        {{ renderNavListItem(child, pageUrl) }}
-      {%- endfor %}
-    </ul>
-  {%- endif %}
-</li>
+  <li class="nav-item">
+    <a
+      href="{{ entry.url }}"
+      {%- if entry.url == pageUrl %}aria-current="page"{% endif %}
+    >
+      {{- entry.title -}}
+    </a>
+    {%- if entry.children.length %}
+      <ul role="list" class="with-dropdown">
+        {%- for child in entry.children %}
+          {{ renderNavListItem(child, pageUrl) }}
+        {%- endfor %}
+      </ul>
+    {%- endif %}
+  </li>
 {%- endmacro %}

--- a/_includes/components/oaklandMap.njk
+++ b/_includes/components/oaklandMap.njk
@@ -3,13 +3,13 @@
   <source
     class="oakland-map-light"
     srcset="
-    /img/oakland-map-light-450w.webp 450w,
-    /img/oakland-map-light-900w.webp 900w,
-    /img/oakland-map-light-1300w.webp 1300w,
-    /img/oakland-map-light-1800w.webp 1800w,
-    /img/oakland-map-light-2600w.webp 2600w,
-    /img/oakland-map-light-3600w.webp 3600w,
-    /img/oakland-map-light-6016w.webp 6016w
+      /img/oakland-map-light-450w.webp   450w,
+      /img/oakland-map-light-900w.webp   900w,
+      /img/oakland-map-light-1300w.webp 1300w,
+      /img/oakland-map-light-1800w.webp 1800w,
+      /img/oakland-map-light-2600w.webp 2600w,
+      /img/oakland-map-light-3600w.webp 3600w,
+      /img/oakland-map-light-6016w.webp 6016w
     "
     type="image/webp"
     media="(prefers-color-scheme: light)"
@@ -18,13 +18,13 @@
   <source
     class="oakland-map-light"
     srcset="
-    /img/oakland-map-light-450w.jpeg 450w,
-    /img/oakland-map-light-900w.jpeg 900w,
-    /img/oakland-map-light-1300w.jpeg 1300w,
-    /img/oakland-map-light-1800w.jpeg 1800w,
-    /img/oakland-map-light-2600w.jpeg 2600w,
-    /img/oakland-map-light-3600w.jpeg 3600w,
-    /img/oakland-map-light-6016w.jpeg 6016w
+      /img/oakland-map-light-450w.jpeg   450w,
+      /img/oakland-map-light-900w.jpeg   900w,
+      /img/oakland-map-light-1300w.jpeg 1300w,
+      /img/oakland-map-light-1800w.jpeg 1800w,
+      /img/oakland-map-light-2600w.jpeg 2600w,
+      /img/oakland-map-light-3600w.jpeg 3600w,
+      /img/oakland-map-light-6016w.jpeg 6016w
     "
     type="image/jpeg"
     media="(prefers-color-scheme: light)"
@@ -33,13 +33,13 @@
   <source
     class="oakland-map-dark"
     srcset="
-    /img/oakland-map-dark-450w.webp 450w,
-    /img/oakland-map-dark-900w.webp 900w,
-    /img/oakland-map-dark-1300w.webp 1300w,
-    /img/oakland-map-dark-1800w.webp 1800w,
-    /img/oakland-map-dark-2600w.webp 2600w,
-    /img/oakland-map-dark-3600w.webp 3600w,
-    /img/oakland-map-dark-6016w.webp 6016w
+      /img/oakland-map-dark-450w.webp   450w,
+      /img/oakland-map-dark-900w.webp   900w,
+      /img/oakland-map-dark-1300w.webp 1300w,
+      /img/oakland-map-dark-1800w.webp 1800w,
+      /img/oakland-map-dark-2600w.webp 2600w,
+      /img/oakland-map-dark-3600w.webp 3600w,
+      /img/oakland-map-dark-6016w.webp 6016w
     "
     type="image/webp"
     media="(prefers-color-scheme: dark)"
@@ -48,13 +48,13 @@
   <source
     class="oakland-map-dark"
     srcset="
-    /img/oakland-map-dark-450w.jpeg 450w,
-    /img/oakland-map-dark-900w.jpeg 900w,
-    /img/oakland-map-dark-1300w.jpeg 1300w,
-    /img/oakland-map-dark-1800w.jpeg 1800w,
-    /img/oakland-map-dark-2600w.jpeg 2600w,
-    /img/oakland-map-dark-3600w.jpeg 3600w,
-    /img/oakland-map-dark-6016w.jpeg 6016w
+      /img/oakland-map-dark-450w.jpeg   450w,
+      /img/oakland-map-dark-900w.jpeg   900w,
+      /img/oakland-map-dark-1300w.jpeg 1300w,
+      /img/oakland-map-dark-1800w.jpeg 1800w,
+      /img/oakland-map-dark-2600w.jpeg 2600w,
+      /img/oakland-map-dark-3600w.jpeg 3600w,
+      /img/oakland-map-dark-6016w.jpeg 6016w
     "
     type="image/jpeg"
     media="(prefers-color-scheme: dark)"

--- a/_includes/components/projectCard.njk
+++ b/_includes/components/projectCard.njk
@@ -1,25 +1,25 @@
 {# Card component for use in work/index #}
 {% macro projectCard(project, thumb = "") %}
-<li class="card">
-  <div class="img">
-    {%- if thumb %}
-      {% dataCascadeImage thumb.image.stats, "" %}
-    {%- else %}
-      Missing thumbnail image!
-    {%- endif %}
-  </div>
-  <div class="text">
-    <h2>
-      <a href="./{{ project.title | slugify }}/">{{ project.title }}</a>
-    </h2>
-    <p>{{ project.description }}</p>
-    {% if project.tags %}
-      <ul class="tags" role="list">
-        {% for tag in project.tags %}
-          <li class="tag">{{tag}}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-  </div>
-</li>
+  <li class="card">
+    <div class="img">
+      {%- if thumb %}
+        {% dataCascadeImage thumb.image.stats, "" %}
+      {%- else %}
+        Missing thumbnail image!
+      {%- endif %}
+    </div>
+    <div class="text">
+      <h2>
+        <a href="./{{ project.title | slugify }}/">{{ project.title }}</a>
+      </h2>
+      <p>{{ project.description }}</p>
+      {% if project.tags %}
+        <ul class="tags" role="list">
+          {% for tag in project.tags %}
+            <li class="tag">{{ tag }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  </li>
 {% endmacro %}

--- a/_includes/components/secondarySiteNav.njk
+++ b/_includes/components/secondarySiteNav.njk
@@ -1,17 +1,17 @@
 {%- macro secondarySiteNav(items, pageUrl, accName) %}
-<nav id="nav-secondary" aria-labelledby="secondary-site-nav-title">
-  <span id="secondary-site-nav-title" hidden>{{ accName }}</span>
-  <ul role="list">
-    {%- for item in items %}
-      <li>
-        <a
-          href="{{item.path}}"
-          {% if pageUrl == item.path %} aria-current="page" {% endif %}
-        >
-          {{item.title}}
-        </a>
-      </li>
-    {%- endfor %}
-  </ul>
-</nav>
+  <nav id="nav-secondary" aria-labelledby="secondary-site-nav-title">
+    <span id="secondary-site-nav-title" hidden>{{ accName }}</span>
+    <ul role="list">
+      {%- for item in items %}
+        <li>
+          <a
+            href="{{ item.path }}"
+            {% if pageUrl == item.path %}aria-current="page"{% endif %}
+          >
+            {{ item.title }}
+          </a>
+        </li>
+      {%- endfor %}
+    </ul>
+  </nav>
 {% endmacro %}

--- a/_includes/components/themeToggle.njk
+++ b/_includes/components/themeToggle.njk
@@ -1,9 +1,6 @@
 {# theme-toggle.css: site wide theme toggle that currently resides in the site's footer #}
-{%- set themes = ["light", "dark", "auto"]  -%}
-<fieldset
-  id="site-theme-toggle"
-  tabindex="-1"
->
+{%- set themes = ["light", "dark", "auto"] -%}
+<fieldset id="site-theme-toggle" tabindex="-1">
   {# NOTE: we use a span here because <legend> doesn't play well with `display: flex` on the fieldset parent #}
   <legend class="visually-hidden">Site Theme:</legend>
   <span aria-hidden="true">Site Theme:</span>
@@ -16,7 +13,7 @@
           type="radio"
           name="site-theme"
           value="{{ theme }}"
-        >
+        />
         {{ theme }}
       </label>
     </div>

--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -2,21 +2,20 @@
   <div class="footer-inner">
     <section>
       <h2>About This Site</h2>
-      <p>Designed and coded with
+      <p>
+        Designed and coded with
         <span aria-hidden="true">♥</span>
         <span class="visually-hidden">love&nbsp;</span>
         by
         <a href="/about/">Chris Henrick</a>
         using
-        <a href="https://www.11ty.dev/">Eleventy</a>.
-        Hosted on
+        <a href="https://www.11ty.dev/">Eleventy</a>. Hosted on
         <a href="https://netlify.com">Netlify</a>.
       </p>
+      <p><span>©</span> Chris Henrick 2015 – current. All rights reserved.</p>
       <p>
-        <span>©</span> Chris Henrick 2015 – current. All rights reserved.
-      </p>
-      <p>
-        Last built on <time datetime="{{ generated.iso }}">{{ generated.formatted }}</time>
+        Last built on
+        <time datetime="{{ generated.iso }}">{{ generated.formatted }}</time>
       </p>
       <ul class="meta-links inline" role="list">
         <li>
@@ -29,7 +28,7 @@
           <a href="/feed.xml">RSS feed</a>
         </li>
         <li>
-          <a href={{metadata.githubRepository}}>Code</a>
+          <a href="{{ metadata.githubRepository }}">Code</a>
         </li>
         <li>
           <a href="/sitemap.xml">Sitemap</a>
@@ -40,11 +39,13 @@
     <section>
       <h2>Social Links</h2>
       <ul class="social-links" role="list">
-      {%- for name, url in metadata.socialLinks %}
-        <li>
-          <a href={{url}} {% if name == "Mastodon" %} rel="me" {% endif %} >{{name}}</a>
-        </li>
-      {%- endfor %}
+        {%- for name, url in metadata.socialLinks %}
+          <li>
+            <a href="{{ url }}" {% if name == "Mastodon" %}rel="me"{% endif %}
+              >{{ name }}</a
+            >
+          </li>
+        {%- endfor %}
       </ul>
     </section>
   </div>

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -109,10 +109,7 @@
   {% include "styles.njk" %}
 
   {# NOTE: prevents a flash of un-themed content. See theme-toggle.js for related code. #}
-  <script>
-    const theme = localStorage.getItem("theme");
-    if (theme) {
-      document.documentElement.dataset.theme = theme;
-    }
-  </script>
+  {# prettier-ignore-start #}
+  <script>const theme=localStorage.getItem("theme");if(theme){document.documentElement.dataset.theme=theme}</script>
+  {# prettier-ignore-end #}
 </head>

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -1,6 +1,7 @@
 {# Sitewide head element used in all pages #}
 {%- set headTitleBase = title or metadata.author.name %}
-{%- set headTitle =
+{%-
+  set headTitle =
   headTitleBase if headTitleBase.includes(metadata.author.name)
   else [headTitleBase, metadata.author.name].join(" – ")
 -%}
@@ -9,68 +10,102 @@
 {%- set headImageType = imageType or metadata.titleImageType %}
 {%- set headOGType = "article" if page.url.includes("/blog/") else "website" %}
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <title>{{ headTitle }}</title>
-  <meta name="description" content="{{ headDescription }}">
-  <meta name="theme-color" content="{{ metadata.metaThemeColorDark }}" media="(prefers-color-scheme: dark)">
-  <meta name="theme-color" content="{{ metadata.metaThemeColorLight }}" media="(prefers-color-scheme: light)">
-
+  <meta name="description" content="{{ headDescription }}" />
+  <meta
+    name="theme-color"
+    content="{{ metadata.metaThemeColorDark }}"
+    media="(prefers-color-scheme: dark)"
+  />
+  <meta
+    name="theme-color"
+    content="{{ metadata.metaThemeColorLight }}"
+    media="(prefers-color-scheme: light)"
+  />
 
   {# Favicons, credit: https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs #}
   {%- if metadata.environment === "production" %}
-  <link rel="icon" href="/favicon/favicon.ico" sizes="32x32">
-  <link rel="icon" href="/favicon/favicon.svg" type="image/svg+xml" sizes="any">
+    <link rel="icon" href="/favicon/favicon.ico" sizes="32x32" />
+    <link
+      rel="icon"
+      href="/favicon/favicon.svg"
+      type="image/svg+xml"
+      sizes="any"
+    />
   {%- else %}
-  <link rel="icon" href="/favicon/favicon-dev.ico" sizes="32x32">
-  <link rel="icon" href="/favicon/favicon-dev.svg" type="image/svg+xml" sizes="any">
+    <link rel="icon" href="/favicon/favicon-dev.ico" sizes="32x32" />
+    <link
+      rel="icon"
+      href="/favicon/favicon-dev.svg"
+      type="image/svg+xml"
+      sizes="any"
+    />
   {%- endif %}
-  <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png">
-  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png" />
+  <link rel="manifest" href="/manifest.webmanifest" />
 
   {# Let's others know this site was created using 11ty #}
-  <meta name="generator" content="{{ eleventy.generator }}">
+  <meta name="generator" content="{{ eleventy.generator }}" />
 
   {# RSS feeds #}
-  <link rel="alternate" href="/feed.xml" type="application/atom+xml" title="{{ metadata.title }}">
-  <link rel="alternate" href="/feed.json" type="application/feed+json" title="{{ metadata.title }}">
+  <link
+    rel="alternate"
+    href="/feed.xml"
+    type="application/atom+xml"
+    title="{{ metadata.title }}"
+  />
+  <link
+    rel="alternate"
+    href="/feed.json"
+    type="application/feed+json"
+    title="{{ metadata.title }}"
+  />
 
   {# SEO #}
-  <meta name="google-site-verification" content="hb0oFgJAnd2i2LvJYSEIofF5sc24xc8hx2tTNittvHA">
-  <meta name="msvalidate.01" content="2515EC227874C1EE104D3FB4124CC9C5">
+  <meta
+    name="google-site-verification"
+    content="hb0oFgJAnd2i2LvJYSEIofF5sc24xc8hx2tTNittvHA"
+  />
+  <meta name="msvalidate.01" content="2515EC227874C1EE104D3FB4124CC9C5" />
 
   {# Fediverse author tags #}
-  <meta name="fediverse:creator" content="{{ metadata.socialHandles.get('Mastodon') }}">
+  <meta
+    name="fediverse:creator"
+    content="{{ metadata.socialHandles.get('Mastodon') }}"
+  />
 
   {# Social: Open Graph tags #}
-  <meta property="og:locale" content="en_US">
-  <meta property="og:title" content="{{ headTitle }}">
-  <meta property="og:description" content="{{ headDescription }}">
-  <meta property="og:logo" content="{{ metadata.url }}{{ metadata.logoImage }}">
-  <meta property="og:type" content={{ headOGType }}>
-  <meta property="og:url" content={{ metadata.url }}{{ page.url.slice(1) }}>
-  <meta property="og:site_name" content={{ metadata.title }}>
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:title" content="{{ headTitle }}" />
+  <meta property="og:description" content="{{ headDescription }}" />
+  <meta
+    property="og:logo"
+    content="{{ metadata.url }}{{ metadata.logoImage }}"
+  />
+  <meta property="og:type" content="{{ headOGType }}" />
+  <meta property="og:url" content="{{ metadata.url }}{{ page.url.slice(1) }}" />
+  <meta property="og:site_name" content="{{ metadata.title }}" />
   {%- if largeImage %}
-  <meta property="og:image" content="{{ metadata.url }}{{ largeImage }}">
+    <meta property="og:image" content="{{ metadata.url }}{{ largeImage }}" />
   {%- elif image %}
-  <meta property="og:image" content="{{ metadata.url }}{{ image }}">
+    <meta property="og:image" content="{{ metadata.url }}{{ image }}" />
   {%- else %}
-  <meta property="og:image" content="{{ metadata.url }}{{ metadata.titleImage }}">
+    <meta
+      property="og:image"
+      content="{{ metadata.url }}{{ metadata.titleImage }}"
+    />
   {%- endif %}
-  <meta property="og:image:alt" content="{{ headImageAlt }}">
-  <meta property="og:image:type" content="{{ headImageType }}">
+  <meta property="og:image:alt" content="{{ headImageAlt }}" />
+  <meta property="og:image:type" content="{{ headImageType }}" />
 
   {# NOTE: All common CSS used throughout the site are added here. In dev they are created as links, in prod all CSS is concatenated and inlined for a small performance boost. #}
   {%- set partials %}
-      base/reset,
-      base/base,
-      base/utils,
-      components/button,
-      components/theme-toggle,
-      layouts/header,
-      layouts/footer
-    {% endset %}
+    base/reset, base/base, base/utils, components/button,
+    components/theme-toggle, layouts/header, layouts/footer
+  {% endset %}
   {% include "styles.njk" %}
 
   {# NOTE: prevents a flash of un-themed content. See theme-toggle.js for related code. #}

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -73,8 +73,8 @@
     {% endset %}
   {% include "styles.njk" %}
 
+  {# NOTE: prevents a flash of un-themed content. See theme-toggle.js for related code. #}
   <script>
-    {# NOTE: prevents a flash of un-themed content. See theme-toggle.js for related code. #}
     const theme = localStorage.getItem("theme");
     if (theme) {
       document.documentElement.dataset.theme = theme;

--- a/_includes/layouts/about.njk
+++ b/_includes/layouts/about.njk
@@ -1,17 +1,16 @@
 ---
 layout: layouts/base.njk
-pages: [
-  { title: "about Chris Henrick", path: "/about/" },
-  { title: "Curriculum Vitae", path: "/about/cv/" },
-  { title: "Talks and Workshops", path: "/about/talks/"},
-  { title: "Accessibility Statement", path: "/about/accessibility/" }
-]
+pages:
+  [
+    { title: "about Chris Henrick", path: "/about/" },
+    { title: "Curriculum Vitae", path: "/about/cv/" },
+    { title: "Talks and Workshops", path: "/about/talks/" },
+    { title: "Accessibility Statement", path: "/about/accessibility/" },
+  ]
 ---
 
 {%- set partials %}
-  components/secondarySiteNav,
-  components/oakland-map,
-  pages/about
+  components/secondarySiteNav, components/oakland-map, pages/about
 {% endset %}
 {%- set bucket = "about" %}
 {% include "styles.njk" %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,23 +4,20 @@
 
   {# NOTE: data-page-size is used to set the max-width of <main> #}
   {%- set defaultPageSize = 'normal' %}
-  <body data-page-size="{{pageSize or defaultPageSize}}">
+  <body data-page-size="{{ pageSize or defaultPageSize }}">
     <script>
       document.body.classList.add("js-enabled");
     </script>
 
     {%- include "header.njk" %}
 
-    <main id="main" tabindex="-1">
-      {{ content | safe }}
-    </main>
+    <main id="main" tabindex="-1">{{ content | safe }}</main>
 
     {%- include "footer.njk" %}
 
     {# NOTE: JavaScript shared by all pages are added here #}
     {%- set javascripts -%}
-      primary-navigation,
-      theme-toggle
+      primary-navigation, theme-toggle
     {%- endset -%}
     {%- include "scripts.njk" -%}
   </body>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -68,13 +68,17 @@ eleventyComputed:
   {%- set nextPost = collections.posts | getNextCollectionItem %}
   {%- if nextPost or previousPost %}
     <ul class="links-nextprev" role="list">
-      {%- if previousPost %}<li>
-        Previous:
-        <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>
-      </li>{% endif %}
-      {%- if nextPost %}<li>
-        Next: <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
-      </li>{% endif %}
+      {%- if previousPost %}
+        <li>
+          Previous:
+          <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>
+        </li>
+      {% endif %}
+      {%- if nextPost %}
+        <li>
+          Next: <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
+        </li>
+      {% endif %}
     </ul>
   {%- endif %}
 {%- endif %}

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -3,29 +3,24 @@ layout: layouts/base.njk
 eleventyComputed:
   kofiUrl: "{{ metadata.socialLinks.get('Ko-Fi') }}"
 ---
+
 {%- set partials %}
-  components/code,
-  components/forms/form-controls,
-  components/forms/select,
-  components/kofi,
-  components/disclosure,
-  pages/post
+  components/code, components/forms/form-controls, components/forms/select,
+  components/kofi, components/disclosure, pages/post
 {%- endset %}
 
 {% if page.fileSlug.includes("oklch") %}
   {% set partials = partials.concat(',', 'pages/blog-posts/color-experiments-oklch/post-styles') %}
 {% endif %}
-
 {%- set bucket = "post" %}
 {% include "styles.njk" %}
-
 {% from "components/kofi.njk" import kofi %}
 
 <article aria-describedby="post-title">
   <h1 id="post-title">{{ title }}</h1>
 
   {%- if teaser %}
-  <p class="post-teaser">{{ teaser }}</p>
+    <p class="post-teaser">{{ teaser }}</p>
   {%- endif %}
 
   <dl class="post-metadata">
@@ -38,24 +33,22 @@ eleventyComputed:
       </dd>
     </div>
     {%- if updated %}
-    <div class="updated-date">
-      <dt>Last updated on:</dt>
-      <dd>
-        <time datetime="{{ updated  | htmlDateString }}">
-          {{ updated | readableDate }}
-        </time>
-      </dd>
-    </div>
+      <div class="updated-date">
+        <dt>Last updated on:</dt>
+        <dd>
+          <time datetime="{{ updated  | htmlDateString }}">
+            {{ updated | readableDate }}
+          </time>
+        </dd>
+      </div>
     {%- endif %}
     <div class="tags">
       <dt>Tagged in:</dt>
       {%- for tag in tags | filterTagList %}
-      {%- set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
-      <dd>
-        <a href="{{ tagUrl }}" class="post-tag">
-          #{{ tag }}
-        </a>
-      </dd>
+        {%- set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
+        <dd>
+          <a href="{{ tagUrl }}" class="post-tag"> #{{ tag }} </a>
+        </dd>
       {%- endfor %}
     </div>
   </dl>
@@ -68,16 +61,20 @@ eleventyComputed:
   {{ content | safe }}
 
   {{ kofi(kofiUrl) }}
-
 </article>
 
 {%- if collections.posts %}
-{%- set previousPost = collections.posts | getPreviousCollectionItem %}
-{%- set nextPost = collections.posts | getNextCollectionItem %}
-{%- if nextPost or previousPost %}
-<ul class="links-nextprev" role="list">
-  {%- if previousPost %}<li>Previous: <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a></li>{% endif %}
-  {%- if nextPost %}<li>Next: <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a></li>{% endif %}
-</ul>
-{%- endif %}
+  {%- set previousPost = collections.posts | getPreviousCollectionItem %}
+  {%- set nextPost = collections.posts | getNextCollectionItem %}
+  {%- if nextPost or previousPost %}
+    <ul class="links-nextprev" role="list">
+      {%- if previousPost %}<li>
+        Previous:
+        <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>
+      </li>{% endif %}
+      {%- if nextPost %}<li>
+        Next: <a href="{{ nextPost.url }}">{{ nextPost.data.title }}</a>
+      </li>{% endif %}
+    </ul>
+  {%- endif %}
 {%- endif %}

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -10,7 +10,9 @@
 <ol reversed class="postlist" role="list">
 {% for post in postslist | reverse %}
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
+    {# prettier-ignore-start #}
     <h{{ headingLevel }}>
+    {# prettier-ignore-end #}
       <a href="{{ post.url }}" class="postlist-link">
       {%- if post.data.title %}
         {{ post.data.title }}
@@ -18,7 +20,9 @@
         <code>{{ post.url }}</code>
       {%- endif %}
       </a>
+    {# prettier-ignore-start #}
     </h{{ headingLevel }}>
+    {# prettier-ignore-end #}
     <div>
       <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">
         {{ post.date | readableDate }}

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,7 +1,12 @@
 {%- css "default" %}
-  .postlist { counter-reset: start-from
-  {{ (postslistCounter or postslist.length) + 1 }} } .postlist li.postlist-item
-  { margin-bottom: 3rem; }
+  {# prettier-ignore-start #}
+.postlist {
+  counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}
+}
+.postlist li.postlist-item {
+  margin-bottom: 3rem;
+}
+{# prettier-ignore-end #}
 {% endcss %}
 {%- set headingLevel = headingLevel if headingLevel else 2 %}
 <ol reversed class="postlist" role="list">

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,37 +1,36 @@
 {%- css "default" %}
-.postlist {
-  counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }}
-}
-.postlist li.postlist-item {
-  margin-bottom: 3rem;
-}
+  .postlist { counter-reset: start-from
+  {{ (postslistCounter or postslist.length) + 1 }} } .postlist li.postlist-item
+  { margin-bottom: 3rem; }
 {% endcss %}
 {%- set headingLevel = headingLevel if headingLevel else 2 %}
 <ol reversed class="postlist" role="list">
-{% for post in postslist | reverse %}
-	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
-    {# prettier-ignore-start #}
+  {% for post in postslist | reverse %}
+    <li
+      class="postlist-item{% if post.url == url %}postlist-item-active{% endif %}"
+    >
+      {# prettier-ignore-start #}
     <h{{ headingLevel }}>
     {# prettier-ignore-end #}
       <a href="{{ post.url }}" class="postlist-link">
-      {%- if post.data.title %}
-        {{ post.data.title }}
-      {%- else %}
-        <code>{{ post.url }}</code>
-      {%- endif %}
+        {%- if post.data.title %}
+          {{ post.data.title }}
+        {%- else %}
+          <code>{{ post.url }}</code>
+        {%- endif %}
       </a>
-    {# prettier-ignore-start #}
+      {# prettier-ignore-start #}
     </h{{ headingLevel }}>
     {# prettier-ignore-end #}
-    <div>
-      <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">
-        {{ post.date | readableDate }}
-      </time>
-    </div>
-    {{ ' ' }}
-    {%- if post.data.teaser -%}
-    <p>{{ post.data.teaser }}</p>
-    {%- endif %}
-	</li>
-{% endfor %}
+      <div>
+        <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">
+          {{ post.date | readableDate }}
+        </time>
+      </div>
+      {{ ' ' }}
+      {%- if post.data.teaser -%}
+        <p>{{ post.data.teaser }}</p>
+      {%- endif %}
+    </li>
+  {% endfor %}
 </ol>

--- a/_includes/scripts.njk
+++ b/_includes/scripts.njk
@@ -19,7 +19,9 @@
 
     {# NOTE: we "bucket" the JS so that we can create separate inlined scripts for shared JS and page / layout specific JS #}
     {# See: https://github.com/11ty/eleventy-plugin-bundle/blob/main/README.md#asset-bucketing #}
+    {# prettier-ignore-start #}
     <script>{% getBundle "js", bucket %}</script>
+    {# prettier-ignore-end #}
 
   {# in development we load all JS via a <script> so that changes to our JS don't require a manual page refresh #}
   {%- else %}

--- a/_includes/scripts.njk
+++ b/_includes/scripts.njk
@@ -23,7 +23,7 @@
     <script>{% getBundle "js", bucket %}</script>
     {# prettier-ignore-end #}
 
-  {# in development we load all JS via a <script> so that changes to our JS don't require a manual page refresh #}
+    {# in development we load all JS via a <script> so that changes to our JS don't require a manual page refresh #}
   {%- else %}
     {%- for path in paths %}
       {%- if regExp.test(path) %}

--- a/_includes/styles.njk
+++ b/_includes/styles.njk
@@ -23,7 +23,7 @@
     <style>{% getBundle "css", bucket %}</style>
     {# prettier-ignore-end #}
 
-  {# in development we load all CSS via a <link> so that changes to our CSS don't require a manual page refresh #}
+    {# in development we load all CSS via a <link> so that changes to our CSS don't require a manual page refresh #}
   {%- else %}
     {%- for path in paths %}
       {%- if regExp.test(path) %}

--- a/_includes/styles.njk
+++ b/_includes/styles.njk
@@ -19,7 +19,9 @@
     {%- endfor %}
     {# NOTE: we "bucket" the CSS so that we can create separate inlined styles for shared / common CSS and page / layout specific CSS #}
     {# See: https://github.com/11ty/eleventy-plugin-bundle/blob/main/README.md#asset-bucketing #}
+    {# prettier-ignore-start #}
     <style>{% getBundle "css", bucket %}</style>
+    {# prettier-ignore-end #}
 
   {# in development we load all CSS via a <link> so that changes to our CSS don't require a manual page refresh #}
   {%- else %}

--- a/content/_redirects.njk
+++ b/content/_redirects.njk
@@ -2,11 +2,13 @@
 permalink: /_redirects
 eleventyExcludeFromCollections: true
 ---
+
 {# NOTE: adds Netlify redirect instructions for all pages with a `redirectFrom : <url>` in the front matter #}
 {%- for page in collections.all %}
   {%- if page.url and page.data.redirectFrom %}
     {%- for oldUrl in page.data.redirectFrom %}
-{{ oldUrl }}  {{ page.url }}
+      {{ oldUrl }}
+      {{ page.url }}
     {%- endfor %}
   {%- endif %}
 {%- endfor %}

--- a/content/_redirects.njk
+++ b/content/_redirects.njk
@@ -7,8 +7,9 @@ eleventyExcludeFromCollections: true
 {%- for page in collections.all %}
   {%- if page.url and page.data.redirectFrom %}
     {%- for oldUrl in page.data.redirectFrom %}
-      {{ oldUrl }}
-      {{ page.url }}
+      {# prettier-ignore-start #}
+      {{ oldUrl }} {{ page.url }}
+      {# prettier-ignore-end #}
     {%- endfor %}
   {%- endif %}
 {%- endfor %}

--- a/content/archive.njk
+++ b/content/archive.njk
@@ -7,6 +7,7 @@ eleventyNavigation:
   parent: Blog
   key: Archive
 ---
+
 {%- set partials %}
   components/posts-list
 {%- endset -%}

--- a/content/blog.njk
+++ b/content/blog.njk
@@ -12,9 +12,9 @@ pagination:
   alias: "posts"
   reverse: true
 ---
+
 {%- set partials %}
-  components/posts-list,
-  pages/blog
+  components/posts-list, pages/blog
 {%- endset -%}
 {%- set bucket = "blog" %}
 {% include "styles.njk" %}
@@ -50,17 +50,17 @@ pagination:
         Next
       </a>
     </li>
-{%- for pageEntry in pagination.pages %}
-    <li>
-      <a
-        class="button"
-        href="{{ pagination.hrefs[ loop.index0 ] }}"
-        {% if page.url == pagination.hrefs[ loop.index0 ] %} aria-current="page"{% endif %}
-      >
-        <span class="visually-hidden">Page</span> {{ loop.index }}
-      </a>
-    </li>
-{%- endfor %}
+    {%- for pageEntry in pagination.pages %}
+      <li>
+        <a
+          class="button"
+          href="{{ pagination.hrefs[ loop.index0 ] }}"
+          {% if page.url == pagination.hrefs[ loop.index0 ] %}aria-current="page"{% endif %}
+        >
+          <span class="visually-hidden">Page</span> {{ loop.index }}
+        </a>
+      </li>
+    {%- endfor %}
   </ol>
   <p>
     You may view all posts in the <a href="/blog/archive/">Blog Archive</a>.

--- a/content/blog/2015-08-10-data-processing-wwc001.md
+++ b/content/blog/2015-08-10-data-processing-wwc001.md
@@ -104,90 +104,114 @@ The output JSON data format I decided on would look something like the following
 
 ```json
 {
-    "country-one" : { // eg: United States
-      "category-one" : { // eg: production
-          "sub-category-one" : { // eg: coal
-              "total" : [  // sample array for total of category-one > sub-category-two
-                {
-                  "year" : 2007,
-                  "val" : 846
-                },
-                {
-                  "year" : 2008,
-                  "val" : 859
-                },
-                {
-                  "year" : 2009,
-                  "val" : 778
-                },
-                {
-                  "year" : 2010,
-                  "val" : 793
-                },
-                {
-                  "year" : 2011,
-                  "val" : 800
-                },
-                {
-                  "year" : 2012,
-                  "val" : 744
-                },
-                {
-                  "year" : 2013,
-                  "val" : 720
-                }
-              ],
-              "per_capita" : [ // sample array for per-capita of category-one > sub-category-two
-                {
-                  "year" : 2007,
-                  "val" : 2.800
-                },
-                {
-                  "year" : 2008,
-                  "val" : 2.825
-                },
-                {
-                  "year" : 2009,
-                  "val" : 2.536
-                },
-                {
-                  "year" : 2010,
-                  "val" : 2.564
-                },
-                {
-                  "year" : 2011,
-                  "val" : 2.568
-                },
-                {
-                  "year" : 2012,
-                  "val" : 2.370
-                },
-                {
-                  "year" : 2013,
-                  "val" : 2.278
-                }
-              ],
-              "source" : ["Energy Information Administration"] // the data's source, this differs country to country
-            },
-          "sub-category-two" : { // eg: gas
-              "total" : [...],
-              "per_capita" : [...],
-              "source" : [...]
-            },
-          // additional sub-categories follow...
+  "country-one": {
+    // eg: United States
+    "category-one": {
+      // eg: production
+      "sub-category-one": {
+        // eg: coal
+        "total": [
+          // sample array for total of category-one > sub-category-two
+          {
+            "year": 2007,
+            "val": 846
           },
-        "category-two" : { // eg: consumption
-          "sub-category-one" : {  // eg: power-sector
-              "total" : [...],
-              "per_capita" : [...],
-              "source" : [...]
-            },
-          // additional sub-categories ...
-        }
-        // additional categories ...
+          {
+            "year": 2008,
+            "val": 859
+          },
+          {
+            "year": 2009,
+            "val": 778
+          },
+          {
+            "year": 2010,
+            "val": 793
+          },
+          {
+            "year": 2011,
+            "val": 800
+          },
+          {
+            "year": 2012,
+            "val": 744
+          },
+          {
+            "year": 2013,
+            "val": 720
+          }
+        ],
+        "per_capita": [
+          // sample array for per-capita of category-one > sub-category-two
+          {
+            "year": 2007,
+            "val": 2.8
+          },
+          {
+            "year": 2008,
+            "val": 2.825
+          },
+          {
+            "year": 2009,
+            "val": 2.536
+          },
+          {
+            "year": 2010,
+            "val": 2.564
+          },
+          {
+            "year": 2011,
+            "val": 2.568
+          },
+          {
+            "year": 2012,
+            "val": 2.37
+          },
+          {
+            "year": 2013,
+            "val": 2.278
+          }
+        ],
+        "source": ["Energy Information Administration"] // the data's source, this differs country to country
       },
-  "country-two" : {...}, // eg: Canada
-  "country-three" : {...} // eg: China
+      "sub-category-two": {
+        // eg: gas
+        "total": [
+          /* ... */
+        ],
+        "per_capita": [
+          /* ... */
+        ],
+        "source": [
+          /* ... */
+        ]
+      }
+      // additional sub-categories follow...
+    },
+    "category-two": {
+      // eg: consumption
+      "sub-category-one": {
+        // eg: power-sector
+        "total": [
+          /* ... */
+        ],
+        "per_capita": [
+          /* ... */
+        ],
+        "source": [
+          /* ... */
+        ]
+      }
+      // additional sub-categories ...
+    }
+    // additional categories ...
+  },
+  "country-two": {
+    /* ... */
+  }, // eg: Canada
+  "country-three": {
+    /* ... */
+  } // eg: China
 }
 ```
 

--- a/content/blog/2015-10-07-using-cartodb-and-datatables.md
+++ b/content/blog/2015-10-07-using-cartodb-and-datatables.md
@@ -13,10 +13,12 @@ tags:
 
 ## Topics Covered
 
-- [Using CartoDB as a datastore](#what-is-cartodb)
-- [Scripting your data wrangling workflow ](#scripting-your-data-wrangling-workflow)
-- [Using the SQL API to load your data to your website / app](#using-the-cartodb-sql-api)
-- [Using the CartoDB JS library to render data on top of an interactive web map](#using-the-cartodb-js-library)
+- [Topics Covered](#topics-covered)
+- [Background](#background)
+- [What is CartoDB?](#what-is-cartodb)
+- [Scripting Your Data Wrangling Workflow](#scripting-your-data-wrangling-workflow)
+- [Using the CartoDB SQL API](#using-the-cartodb-sql-api)
+- [Using the CartoDB JS Library](#using-the-cartodb-js-library)
 
 ## Background
 
@@ -86,22 +88,44 @@ The Response will be in JSON format and have the following structure:
 
 ```json
 {
-    "rows": [
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        {...},
-        ...
-        ],
-    "time": 0.01,
-    "fields": {...},
-    "total_rows": 1649
+  "rows": [
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    },
+    {
+      /* ... */
+    }
+    /* ... */
+  ],
+  "time": 0.01,
+  "fields": {
+    /* ... */
+  },
+  "total_rows": 1649
 }
 ```
 
@@ -109,17 +133,16 @@ Each row has data stored in an object with the column name as the key and that c
 
 ```json
 {
-    "nameoforganization": "Community Parents, Inc.",
-    "neighborhood": "Bedford-Stuyvesant",
-    "addressline1": "90 Chauncey Street",
-    "addressline2": "Brooklyn, NY",
-    "zipcode": "11233",
-    "communityboardnumber": "3",
-    "phonenumber": "718-771-4002",
-    "alternativecontact": "",
-    "website": "http://www.headstartsbc.org",
-    "category1": "Pre-School & Childcare",
-    ...
+  "nameoforganization": "Community Parents, Inc.",
+  "neighborhood": "Bedford-Stuyvesant",
+  "addressline1": "90 Chauncey Street",
+  "addressline2": "Brooklyn, NY",
+  "zipcode": "11233",
+  "communityboardnumber": "3",
+  "phonenumber": "718-771-4002",
+  "alternativecontact": "",
+  "website": "http://www.headstartsbc.org",
+  "category1": "Pre-School & Childcare"
 }
 ```
 

--- a/content/blog/2016-05-08-es6-template-strings-sql.md
+++ b/content/blog/2016-05-08-es6-template-strings-sql.md
@@ -32,14 +32,19 @@ ORDER BY b.display_name, year;
 Previously, if I wanted to keep the SQL human readable in my JS code I would've done something like:
 
 ```js
-var tableOne = 'table_one';
-var tableTwo = 'table_two';
+var tableOne = "table_one";
+var tableTwo = "table_two";
 
-var query = "SELECT a.year, a.season, b.display_name " +
-"FROM " + tableOne + " a," + tableTwo  " b " +
-"WHERE a.id = b.transmitter AND season != 'other' " +
-"GROUP BY a.year, a.season, b.display_name " +
-"ORDER BY b.display_name, year;"
+var query =
+  "SELECT a.year, a.season, b.display_name " +
+  "FROM " +
+  tableOne +
+  " a," +
+  tableTwo +
+  " b " +
+  "WHERE a.id = b.transmitter AND season != 'other' " +
+  "GROUP BY a.year, a.season, b.display_name " +
+  "ORDER BY b.display_name, year;";
 ```
 
 You have to be really careful when doing this and not to mention it's pretty ugly, right? With ES6 template strings the above can simply become:
@@ -60,11 +65,12 @@ let query = `
 That's much easier to write, read, and to avoid syntax errors in your SQL. There's one catch though, if we were to log that template string as it is right now it would look like:
 
 ```js
-"  SELECT a.year, a.season, b.display_name
+`
+  SELECT a.year, a.season, b.display_name
   FROM table_one a, table_two b
   WHERE a.id = b.transmitter AND season != 'other'
   GROUP BY a.year, a.season, b.display_name
-  ORDER BY b.display_name, year;"
+  ORDER BY b.display_name, year;`;
 ```
 
 That's not how we'd want to pass it off as part of the body to a `GET` request to our database. Although CartoDB's API is fairly good a removing extra white space, the newline (`\n`) characters would screw up our query once the API attempts to run it on our database. However, there's an easy way to deal with this problem: use a function that strips out those pesky `\n`'s and indentation space so that the template string becomes a single line string.

--- a/content/blog/2016-12-12-d3-v4-general-update-pattern-punchcard-chart.md
+++ b/content/blog/2016-12-12-d3-v4-general-update-pattern-punchcard-chart.md
@@ -15,8 +15,9 @@ tags:
 
 ### TOC
 
+- [TOC](#toc)
 - [Introduction](#introduction)
-- [The Static Barley Punchcard](#the-static-barley-punchcard-chart)
+- [The Static Barley Punchcard Chart](#the-static-barley-punchcard-chart)
 - [About the Nested Data Structure](#about-the-nested-data-structure)
 - [Steps Towards a Dynamic Chart Using d3-dispatch](#steps-towards-a-dynamic-chart-using-d3-dispatch)
 - [Setting Up the Dropdown](#setting-up-the-dropdown)
@@ -196,32 +197,44 @@ Let's take a look at our nested data:
 [
   {
     "key": "StPaul",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   },
   {
     "key": "Duluth",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   },
   {
     "key": "Waseca",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   },
   {
     "key": "GrandRapids",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   },
   {
     "key": "Morris",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   },
   {
     "key": "Crookston",
-    "values": [...]
+    "values": [
+      /* ... */
+    ]
   }
 ]
 ```
 
-_Note that `[...]` is just a place holder for a non-empty array._
+_Note that `[/* ... */]` is just a place holder for a non-empty array._
 
 We can see that `nested` is an array of six objects, and each object has a `key` and `values` property. Here, each `key` represents a unique "site" in our data such as "StPaul", "Duluth", "Waseca", etc. This is the result of:
 
@@ -233,101 +246,122 @@ d3.next().key(function (d) {
 
 In the static chart we are using the 5th object in this array, which is for the site "Morris". The data contained in `values` for each of these objects is another array of objects, so let's check that out too, starting with `values` array for "StPaul":
 
-```json
+```js
 [
   {
-    "key": "StPaul",
-    "values": [
+    key: "StPaul",
+    values: [
       {
-        "key": "Manchuria",
-        "values": [...]
+        key: "Manchuria",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "Glabron",
-        "values": [...]
+        key: "Glabron",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "Svansota",
-        "values": [...]
+        key: "Svansota",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "Velvet",
-        "values": [...]
+        key: "Velvet",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "Trebi",
-        "values": [...]
+        key: "Trebi",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "ManxSA",
-        "values": [...]
+        key: "ManxSA",
+        values: [
+          /* ... */
+        ],
       },
       {
-        "key": "SAxMan",
-        "values": [...]
+        key: "SAxMan",
+        values: [
+          /* ... */
+        ],
       },
-      ...
+      /* ... */
+    ],
   },
-  ...
-]
+  /* ... */
+];
 ```
 
-_Note: `...` implies more data, omitted for the sake of brevity._
+_Note: `/* ... */` implies more data, omitted for the sake of brevity._
 
 Again, we have an array of objects, with each object containing the properties `key` and `values`. Each of these object's `key` property represents a barley variety or `gen`. This array of objects is the result of the second invocation of `.key()` in the `var nested` code block:
 
 ```js
-  .key(function(d) { return d.gen; })
+var nested = d3
+  .nest()
+  // ...
+  .key(function (d) {
+    return d.gen;
+  })
+  .entries(data);
 ```
 
 Notice that the value of each `key` property matches a name in the y axis for our punchcard chart _(hint hint)_.
 
 If we dig one level deeper and inspect the `values` array of each of these objects, for example `nested[0].values[0].values`, we'll find objects that have the same structure to the objects in `data`:
 
-```json
+```js
 [
   {
-    "key": "StPaul",
-    "values": [
+    key: "StPaul",
+    values: [
       {
-        "key": "Manchuria",
-        "values": [
+        key: "Manchuria",
+        values: [
           {
-            "id": "1",
-            "yield": 47.5,
-            "gen": "Manchuria",
-            "year": 1927,
-            "site": "StPaul"
+            id: "1",
+            yield: 47.5,
+            gen: "Manchuria",
+            year: 1927,
+            site: "StPaul",
           },
           {
-            "id": "54",
-            "yield": 32.9,
-            "gen": "Manchuria",
-            "year": 1928,
-            "site": "StPaul"
+            id: "54",
+            yield: 32.9,
+            gen: "Manchuria",
+            year: 1928,
+            site: "StPaul",
           },
           {
-            "id": "103",
-            "yield": 48.9,
-            "gen": "Manchuria",
-            "year": 1929,
-            "site": "StPaul"
+            id: "103",
+            yield: 48.9,
+            gen: "Manchuria",
+            year: 1929,
+            site: "StPaul",
           },
           {
-            "id": "171",
-            "yield": 34.1,
-            "gen": "Manchuria",
-            "year": 1930,
-            "site": "StPaul"
+            id: "171",
+            yield: 34.1,
+            gen: "Manchuria",
+            year: 1930,
+            site: "StPaul",
           },
-          ...
+          // ...
         ],
       },
-      ...
-    ]
+      // ...
+    ],
   },
-  ...
-]
+  // ...
+];
 ```
 
 These objects are used to generate each circle in the punchcard. The value of `year` is used to map the circle's x position to a given year in the x axis, while the value of `yield` is mapped to the radius of the circle, with help from `d3.scaleLinear` and `d3.scaleSqrt` respectively. Our y axis value, `gen` isn't used when creating the circles as their parent SVG group elements have already been positioned on the y axis. We can also see that the all values for `gen` are "Manchuria" and all values for `site` are "StPaul", matching the nesting of our data structure. The numbers for each `id` further inform us that `d3.nest` has re-arranged our data, for if you inspect the array in `data` from `d3.csv` you'll see that the values for `id` increase sequentially by a factor of 1 starting at 1, or the equivalent of an object's index + 1.
@@ -472,10 +506,12 @@ Finally we need to make sure that the dropdown stays set on the last option the 
 
 E.g., for the site "Morris" the object looks like:
 
-```js
+```json
 {
-  key: "Morris",
-  values: [...]
+  "key": "Morris",
+  "values": [
+    /* ... */
+  ]
 }
 ```
 

--- a/content/blog/2017-06-23-es6-spread-operator-mishap.md
+++ b/content/blog/2017-06-23-es6-spread-operator-mishap.md
@@ -33,19 +33,19 @@ const o2 = {
 
 then the value of `o2` would be:
 
-```js
+```json
 {
-  a: 1,
-  b: 1
+  "a": 1,
+  "b": 1
 }
 ```
 
 **Not** what I wanted or expected! The output I wanted was:
 
-```js
+```json
 {
-  a: 1,
-  b: 5
+  "a": 1,
+  "b": 5
 }
 ```
 

--- a/content/blog/2019-12-15-animating-svg-d3-react-hooks.md
+++ b/content/blog/2019-12-15-animating-svg-d3-react-hooks.md
@@ -121,7 +121,7 @@ Using this zoom interpolator from D3JS with the math from above, we may create a
 function getTransformStr(t) {
   const view = interpolator(t);
   const k = Math.min(width, height) / view[2]; // scale
-  const translate = [width / 2 - view[0] _ k, height / 2 - view[1] _ k]; // translate
+  const translate = [width / 2 - view[0] * k, height / 2 - view[1] * k]; // translate
   return `translate(${translate}) scale(${k})`;
 }
 ```

--- a/content/blog/2021-02-07-prototyping-with-observable-notebooks.md
+++ b/content/blog/2021-02-07-prototyping-with-observable-notebooks.md
@@ -69,6 +69,7 @@ d3 = require("d3@6");
 
 One common use case of an import in an Observable Notebook is utilizing HTML inputs that are configured as “views.” A “view” is similar to the concept of data binding. This type of imported component saves you from having to write the equivalent of event handlers in Observable. Instead you only need to write:
 
+<!-- prettier-ignore -->
 ```js
 viewof myinput = inputType({ /* config options */ });
 ```
@@ -111,6 +112,7 @@ One problem that I ran into quickly with prototyping in Observable had to do wit
 
 For example, say you import a cell called `chart` from a notebook that renders a bar chart, but you want to use your own data, not the data from the bar chart’s notebook. To do that you would override the notebook’s `data` cell with your own cell that has your more awesome data. It’s worth noting that for this to work you would need your data’s schema or structure to match that of the imported data. This type of import might look like the following:
 
+<!-- prettier-ignore -->
 ```js
 import {chart as barChart}
 with {my_data as data}
@@ -121,6 +123,7 @@ In the code above, the original cell that renders the bar chart (called `chart`)
 
 The problem with this approach is that if you need to render a chart more than one time, you need to repeat this type of import statement each time you need to render a chart, which is not very D.R.Y. (Do Not Repeat Yourself):
 
+<!-- prettier-ignore -->
 ```js
 import {chart as chart1} with {my_data1 as data} from "@d3/bar-chart"
 import {chart as chart2} with {my_data2 as data} from "@d3/bar-chart"

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -9,9 +9,7 @@ eleventyNavigation:
 ---
 
 {%- set partials %}
-  components/forms/form-controls,
-  components/button,
-  pages/contact
+  components/forms/form-controls, components/button, pages/contact
 {%- endset %}
 {%- set bucket = "contact" %}
 {% include "styles.njk" %}
@@ -19,7 +17,8 @@ eleventyNavigation:
 <h1>{{ title }}</h1>
 
 <p>
-  You may contact me using the form on this page. You may also email me at <a href="mailto:chrishenrick@gmail.com">chrishenrick@gmail.com</a>.
+  You may contact me using the form on this page. You may also email me at
+  <a href="mailto:chrishenrick@gmail.com">chrishenrick@gmail.com</a>.
 </p>
 
 <form
@@ -42,7 +41,7 @@ eleventyNavigation:
       id="full-name"
       required=""
       autocomplete="name"
-    >
+    />
   </div>
 
   <div class="form-control-group">
@@ -55,7 +54,7 @@ eleventyNavigation:
       required=""
       autocomplete="on"
       inputmode="email"
-    >
+    />
   </div>
 
   <div class="form-control-group">
@@ -76,10 +75,10 @@ eleventyNavigation:
     name="_subject"
     id="email-subject"
     value="Contact Form Submission"
-  >
+  />
 
   {# NOTE: for honey pot spam filtering. See: https://help.formspree.io/hc/en-us/articles/360013580813-Honeypot-spam-filtering #}
-  <input id="s-h-p" type="text" name="_gotcha" value=""/>
+  <input id="s-h-p" type="text" name="_gotcha" value="" />
 
   <button class="button" type="submit">Submit</button>
 </form>

--- a/content/feed/feed.njk
+++ b/content/feed/feed.njk
@@ -2,13 +2,16 @@
 # Metadata comes from _data/metadata.js
 permalink: /feed.xml
 ---
+
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.language }}">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.description }}</subtitle>
-  <link href="{{ permalink | htmlBaseUrl(metadata.url) }}" rel="self"/>
-  <link href="{{ metadata.url | addPathPrefixToFullUrl }}"/>
-  <updated>{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+  <link href="{{ permalink | htmlBaseUrl(metadata.url) }}" rel="self" />
+  <link href="{{ metadata.url | addPathPrefixToFullUrl }}" />
+  <updated
+    >{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339 }}</updated
+  >
   <id>{{ metadata.url }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
@@ -18,10 +21,12 @@ permalink: /feed.xml
     {% set absolutePostUrl %}{{ post.url | htmlBaseUrl(metadata.url) }}{% endset %}
     <entry>
       <title>{{ post.data.title }}</title>
-      <link href="{{ absolutePostUrl }}"/>
+      <link href="{{ absolutePostUrl }}" />
       <updated>{{ post.date | dateToRfc3339 }}</updated>
       <id>{{ absolutePostUrl }}</id>
-      <content type="html">{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) }}</content>
+      <content type="html"
+        >{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) }}</content
+      >
     </entry>
   {%- endfor %}
 </feed>

--- a/content/feed/json.njk
+++ b/content/feed/json.njk
@@ -1,20 +1,31 @@
+{# prettier-ignore-start #}
 ---
 # Metadata comes from _data/metadata.js
 permalink: /feed.json
 ---
-
-{ "version": "https://jsonfeed.org/version/1.1", "title":
-"{{ metadata.title }}", "language": "{{ metadata.language }}", "home_page_url":
-"{{ metadata.url | addPathPrefixToFullUrl }}", "feed_url":
-"{{ permalink | htmlBaseUrl(metadata.url) }}", "description":
-"{{ metadata.description }}", "author": { "name": "{{ metadata.author.name }}",
-"url": "{{ metadata.author.url }}" }, "items": [
-{%- for post in collections.posts | reverse %}
-  {%- set absolutePostUrl = post.url | htmlBaseUrl(metadata.url) %}
-  { "id": "{{ absolutePostUrl }}", "url": "{{ absolutePostUrl }}", "title":
-  "{{ post.data.title }}", "content_html":
-  {% if post.templateContent %}{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}{% else %}""{% endif %},
-  "date_published": "{{ post.date | dateToRfc3339 }}" }
-  {% if not loop.last %},{% endif %}
-{%- endfor %}
-] }
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "{{ metadata.title }}",
+  "language": "{{ metadata.language }}",
+  "home_page_url": "{{ metadata.url | addPathPrefixToFullUrl }}",
+  "feed_url": "{{ permalink | htmlBaseUrl(metadata.url) }}",
+  "description": "{{ metadata.description }}",
+  "author": {
+    "name": "{{ metadata.author.name }}",
+    "url": "{{ metadata.author.url }}"
+  },
+  "items": [
+    {%- for post in collections.posts | reverse %}
+    {%- set absolutePostUrl = post.url | htmlBaseUrl(metadata.url) %}
+    {
+      "id": "{{ absolutePostUrl }}",
+      "url": "{{ absolutePostUrl }}",
+      "title": "{{ post.data.title }}",
+      "content_html": {% if post.templateContent %}{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}{% else %}""{% endif %},
+      "date_published": "{{ post.date | dateToRfc3339 }}"
+    }
+    {% if not loop.last %},{% endif %}
+    {%- endfor %}
+  ]
+}
+{# prettier-ignore-end #}

--- a/content/feed/json.njk
+++ b/content/feed/json.njk
@@ -2,28 +2,19 @@
 # Metadata comes from _data/metadata.js
 permalink: /feed.json
 ---
-{
-	"version": "https://jsonfeed.org/version/1.1",
-	"title": "{{ metadata.title }}",
-	"language": "{{ metadata.language }}",
-	"home_page_url": "{{ metadata.url | addPathPrefixToFullUrl }}",
-	"feed_url": "{{ permalink | htmlBaseUrl(metadata.url) }}",
-	"description": "{{ metadata.description }}",
-	"author": {
-		"name": "{{ metadata.author.name }}",
-		"url": "{{ metadata.author.url }}"
-	},
-	"items": [
-		{%- for post in collections.posts | reverse %}
-		{%- set absolutePostUrl = post.url | htmlBaseUrl(metadata.url) %}
-		{
-			"id": "{{ absolutePostUrl }}",
-			"url": "{{ absolutePostUrl }}",
-			"title": "{{ post.data.title }}",
-			"content_html": {% if post.templateContent %}{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}{% else %}""{% endif %},
-			"date_published": "{{ post.date | dateToRfc3339 }}"
-		}
-		{% if not loop.last %},{% endif %}
-		{%- endfor %}
-	]
-}
+
+{ "version": "https://jsonfeed.org/version/1.1", "title":
+"{{ metadata.title }}", "language": "{{ metadata.language }}", "home_page_url":
+"{{ metadata.url | addPathPrefixToFullUrl }}", "feed_url":
+"{{ permalink | htmlBaseUrl(metadata.url) }}", "description":
+"{{ metadata.description }}", "author": { "name": "{{ metadata.author.name }}",
+"url": "{{ metadata.author.url }}" }, "items": [
+{%- for post in collections.posts | reverse %}
+  {%- set absolutePostUrl = post.url | htmlBaseUrl(metadata.url) %}
+  { "id": "{{ absolutePostUrl }}", "url": "{{ absolutePostUrl }}", "title":
+  "{{ post.data.title }}", "content_html":
+  {% if post.templateContent %}{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}{% else %}""{% endif %},
+  "date_published": "{{ post.date | dateToRfc3339 }}" }
+  {% if not loop.last %},{% endif %}
+{%- endfor %}
+] }

--- a/content/feed/json.njk
+++ b/content/feed/json.njk
@@ -1,4 +1,3 @@
-{# prettier-ignore-start #}
 ---
 # Metadata comes from _data/metadata.js
 permalink: /feed.json
@@ -28,4 +27,3 @@ permalink: /feed.json
     {%- endfor %}
   ]
 }
-{# prettier-ignore-end #}

--- a/content/index.njk
+++ b/content/index.njk
@@ -7,9 +7,7 @@ eleventyComputed:
 ---
 
 {%- set partials %}
-  components/posts-list,
-  components/oakland-map,
-  pages/home
+  components/posts-list, components/oakland-map, pages/home
 {%- endset %}
 {%- set bucket = "home" %}
 {% include "styles.njk" %}
@@ -28,9 +26,9 @@ eleventyComputed:
     {% for service in services %}
       <li class="card">
         <div class="text">
-          <h3>{{service.title}}</h3>
-          <p>{{service.description}}</p>
-          <a class="button" href="{{service.url}}">{{service.cta}}</a>
+          <h3>{{ service.title }}</h3>
+          <p>{{ service.description }}</p>
+          <a class="button" href="{{ service.url }}">{{ service.cta }}</a>
         </div>
       </li>
     {% endfor %}
@@ -46,9 +44,11 @@ eleventyComputed:
   {%- set postslistCounter = postsCount %}
   {%- set headingLevel = 3 %}
   {%- include "postslist.njk" %}
-
   {%- set morePosts = postsCount - numberOfLatestPostsToShow %}
   {%- if morePosts > 0 %}
-    <p>{{ morePosts }} more post{% if morePosts != 1 %}s{% endif %} can be found in <a href="/blog/archive/">the archive</a>.</p>
+    <p>
+      {{ morePosts }} more post{% if morePosts != 1 %}s{% endif %} can be found
+      in <a href="/blog/archive/">the archive</a>.
+    </p>
   {%- endif %}
 </section>

--- a/content/search/index.njk
+++ b/content/search/index.njk
@@ -13,18 +13,17 @@ eleventyNavigation:
 {%- set searchPrefix = ["site:", websiteName] | join %}
 
 {%- set partials %}
-  components/button,
-  components/forms/form-controls,
-  pages/search
+  components/button, components/forms/form-controls, pages/search
 {%- endset %}
 {%- set bucket="search" %}
 {% include "styles.njk" %}
 
-<h1>
-  {{title}}
-</h1>
+<h1>{{ title }}</h1>
 
-<p>Search the contents of this site using <a href="https://duckduckgo.com?q={{searchPrefix}}">DuckDuckGo</a>.</p>
+<p>
+  Search the contents of this site using
+  <a href="https://duckduckgo.com?q={{ searchPrefix }}">DuckDuckGo</a>.
+</p>
 
 {# NOTE: this form is progressively enhanced, it will work without JavaScript! #}
 <form
@@ -36,9 +35,9 @@ eleventyNavigation:
 >
   <span id="search-title" hidden>Site</span>
   {# set region for search #}
-  <input type="hidden" name="ki" value="us-en">
+  <input type="hidden" name="ki" value="us-en" />
   {# disable ads in search results #}
-  <input type="hidden" name="k1" value="-1">
+  <input type="hidden" name="k1" value="-1" />
   <label for="search-text">Search Query</label>
   <input
     id="search-text"
@@ -48,10 +47,9 @@ eleventyNavigation:
     {# NOTE: tried adding an <input type="hidden"> with the "site:name" value, but DDG seems to only keep the last "q" query param value, so it gets replaced by the users search query. #}
     value="{{ searchPrefix }} "
     required=""
-  >
+  />
   <button class="button" type="submit">Search</button>
 </form>
-
 
 {%- set javascripts -%}
   search

--- a/content/sitemap.xml.njk
+++ b/content/sitemap.xml.njk
@@ -2,8 +2,12 @@
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 ---
+
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+>
   {%- for page in collections.all %}
     {% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}
     <url>

--- a/content/tags-list.njk
+++ b/content/tags-list.njk
@@ -3,11 +3,12 @@ permalink: /tags/
 layout: layouts/home.njk
 title: "All Blog Tags"
 ---
-<h1>{{title}}</h1>
+
+<h1>{{ title }}</h1>
 
 <ul>
-{% for tag in collections.all | getAllTags | filterTagList %}
-	{% set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
-	<li><a href="{{ tagUrl }}" class="post-tag">{{ tag }}</a></li>
-{% endfor %}
+  {% for tag in collections.all | getAllTags | filterTagList %}
+    {% set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
+    <li><a href="{{ tagUrl }}" class="post-tag">{{ tag }}</a></li>
+  {% endfor %}
 </ul>

--- a/content/tags.njk
+++ b/content/tags.njk
@@ -14,6 +14,7 @@ eleventyComputed:
   title: Tagged “{{ tag }}”
 permalink: /tags/{{ tag | slugify }}/
 ---
+
 <h1>Tagged “{{ tag }}”</h1>
 
 {% set postslist = collections[ tag ] %}

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -6,13 +6,10 @@ eleventyNavigation:
 ---
 
 {%- set partials %}
-  components/disclosure,
-  components/project-card,
-  pages/work
+  components/disclosure, components/project-card, pages/work
 {%- endset %}
 {%- set bucket = "work" %}
 {% include "styles.njk" %}
-
 {% from "components/projectCard.njk" import projectCard %}
 
 <h1>Portfolio</h1>
@@ -20,17 +17,30 @@ eleventyNavigation:
 <details open>
   <summary>About</summary>
   <p>
-  Featured projects I've created or contributed to over the years. This work spans the domains of web development and design, interactive data visualization, user interface design, interaction design, and cartographic design.
-</p>
+    Featured projects I've created or contributed to over the years. This work
+    spans the domains of web development and design, interactive data
+    visualization, user interface design, interaction design, and cartographic
+    design.
+  </p>
 </details>
 
 <details open data-id="project-filters-disclosure">
   <summary id="filter-projects-title">Filter Projects</summary>
-  <div role="group" class="project-filters" aria-labelledby="filter-projects-title">
+  <div
+    role="group"
+    class="project-filters"
+    aria-labelledby="filter-projects-title"
+  >
     <button value="all" class="button filter" aria-pressed="true">all</button>
-    <button value="web" class="button filter" aria-pressed="false">interactive</button>
-    <button value="data-viz" class="button filter" aria-pressed="false">data viz</button>
-    <button value="cartography" class="button filter" aria-pressed="false">cartography</button>
+    <button value="web" class="button filter" aria-pressed="false">
+      interactive
+    </button>
+    <button value="data-viz" class="button filter" aria-pressed="false">
+      data viz
+    </button>
+    <button value="cartography" class="button filter" aria-pressed="false">
+      cartography
+    </button>
     <button class="button shuffle">shuffle!</button>
   </div>
 </details>
@@ -47,8 +57,7 @@ eleventyNavigation:
 <div id="announce" class="visually-hidden" aria-live="polite"></div>
 
 {%- set javascripts -%}
-  work,
-  disclosure-widgets
+  work, disclosure-widgets
 {%- endset -%}
 {%- set bucket = "work" -%}
 {%- include "scripts.njk" -%}

--- a/content/work/project-pages.njk
+++ b/content/work/project-pages.njk
@@ -13,64 +13,60 @@ eleventyComputed:
 ---
 
 {%- set partials %}
-  components/disclosure,
-  components/embed,
-  components/kofi,
-  pages/project-pages
+  components/disclosure, components/embed, components/kofi, pages/project-pages
 {%- endset %}
 {%- set bucket = "project-pages" %}
 {% include "styles.njk" %}
-
 {% from "components/kofi.njk" import kofi %}
 
 <section>
-  <h1>{{project.title}}</h1>
+  <h1>{{ project.title }}</h1>
 
   <dl>
     {% if project.date %}
-    <div>
-      <dt>Date:</dt>
-      <dd>{{project.date | dateFromISOString("LLLL, yyyy")}}</dd>
-    </div>
+      <div>
+        <dt>Date:</dt>
+        <dd>{{ project.date | dateFromISOString("LLLL, yyyy") }}</dd>
+      </div>
     {% endif %}
 
     {% if project.link %}
-    <div>
-      <dt>Project link:</dt>
-      <dd>
-        <a href={{project.link}} target="_blank">{{project.title}}</a>
-      </dd>
-    </div>
+      <div>
+        <dt>Project link:</dt>
+        <dd>
+          <a href="{{ project.link }}" target="_blank">{{ project.title }}</a>
+        </dd>
+      </div>
     {% endif %}
 
     {% if project.code %}
-    <div>
-      <dt>Code:</dt>
-      {% if project.code | isArray %}
-        {% for link in project.code %}
-        <dd>
-          <a href={{link}} target="_blank">{{link}}</a>
-        </dd>
-        {% endfor %}
-      {% else %}
-      <dd>
-        <a href={{project.code}} target="_blank">{{project.code}}</a>
-      </dd>
-      {% endif %}
-    </div>
+      <div>
+        <dt>Code:</dt>
+        {% if project.code | isArray %}
+          {% for link in project.code %}
+            <dd>
+              <a href="{{ link }}" target="_blank">{{ link }}</a>
+            </dd>
+          {% endfor %}
+        {% else %}
+          <dd>
+            <a href="{{ project.code }}" target="_blank">{{ project.code }}</a>
+          </dd>
+        {% endif %}
+      </div>
     {% endif %}
   </dl>
 </section>
 
 {% if project.tech %}
-<section>
-  <h2>Technologies Used</h2>
-  <ul class="tech-tags" role="list">
-    {% for tag in project.tech %}
-    <li>{{tag}}</li>
-    {% endfor %}
-  </ul>
-</section>
+  <section>
+    <h2>Technologies Used</h2>
+    <ul class="tech-tags" role="list">
+      {% for tag in project.tech %}
+        <li>{{ tag }}</li>
+      {% endfor %}
+    </ul>
+  </section>
 {% endif %}
 
 <section>
@@ -83,30 +79,30 @@ eleventyComputed:
   {% endif %}
 
   {% if project.video %}
-  <div style="--aspect-ratio: 16/9;margin-bottom:2.5rem;">
-    <iframe
-      width="960"
-      height="569"
-      src="{{project.video.embed}}"
-      srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href={{project.video.embed}}><img src='/img/{{project.video.thumb}}' alt='{{project.video.alt}}'><span aria-hidden='true'>▶</span></a>"
-      frameborder="0"
-      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen
-      title="{{project.video.title}}"
-    ></iframe>
-  </div>
+    <div style="--aspect-ratio: 16/9;margin-bottom:2.5rem;">
+      <iframe
+        width="960"
+        height="569"
+        src="{{ project.video.embed }}"
+        srcdoc="<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href={{ project.video.embed }}><img src='/img/{{ project.video.thumb }}' alt='{{ project.video.alt }}'><span aria-hidden='true'>▶</span></a>"
+        frameborder="0"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        title="{{ project.video.title }}"
+      ></iframe>
+    </div>
   {% endif %}
 
   {% if project.imgs %}
-  <ul class="screenshots" role="list">
-    {% for img in project.imgs %}
-    <li>
-      {%- set altText %}Screenshot {{loop.index}} of {{project.title}}{%- endset %}
-      {# NOTE: the code below uses the image shortcode #}
-      {%- image img, altText, constants.IMAGE_WIDTHS_WIDE_PAGE_LAYOUT, constants.IMAGE_SIZES_WIDE_PAGE_LAYOUT %}
-    </li>
-    {% endfor %}
-  </ul>
+    <ul class="screenshots" role="list">
+      {% for img in project.imgs %}
+        <li>
+          {%- set altText %}Screenshot {{ loop.index }} of {{ project.title }}{%- endset %}
+          {# NOTE: the code below uses the image shortcode #}
+          {%- image img, altText, constants.IMAGE_WIDTHS_WIDE_PAGE_LAYOUT, constants.IMAGE_SIZES_WIDE_PAGE_LAYOUT %}
+        </li>
+      {% endfor %}
+    </ul>
   {% endif %}
 </section>
 
@@ -114,7 +110,8 @@ eleventyComputed:
 
 <nav class="secondary" aria-label="secondary">
   <a href="/work/">
-    <span aria-hidden="true" class="back-arrow">&#8619;</span> Go back to the Portfolio
+    <span aria-hidden="true" class="back-arrow">&#8619;</span> Go back to the
+    Portfolio
   </a>
   <a href="#main" aria-labelledby="back-top">
     <span id="back-top" hidden>Go back to top of page</span>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -219,15 +219,21 @@ async function transformMinifyJs(content) {
   return content;
 }
 
-function transformMinifyHtml(content) {
-  if ((this.page.outputPath || "").endsWith(".html")) {
-    let minified = htmlmin.minify(content, {
-      useShortDoctype: true,
-      removeComments: true,
-      collapseWhitespace: true,
-    });
+const htmlminOptions = {
+  useShortDoctype: true,
+  removeComments: true,
+  collapseWhitespace: true,
+  continueOnParseError: true,
+};
 
-    return minified;
+async function transformMinifyHtml(content) {
+  if ((this.page.outputPath || "").endsWith(".html")) {
+    try {
+      let minified = await htmlmin.minify(content, htmlminOptions);
+      return minified;
+    } catch (error) {
+      console.error("problem minifying html: ", error);
+    }
   }
   // If not an HTML output, return content as-is
   return content;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "postcss": "^8.4.38",
     "postcss-minify": "^1.1.0",
     "prettier": "3.4.1",
+    "prettier-plugin-jinja-template": "^2.0.0",
     "prismjs": "^1.29.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard": "^36.0.1",


### PR DESCRIPTION
- uses [prettier-plugin-jinja-template](https://github.com/davidodenwald/prettier-plugin-jinja-template) to format `.njk` files
- formats existing `.njk` files except for excluded ones (autogenerated `lineChart*.njk` files)
- fixes some code block syntax errors in blog post markdown files