### PR TITLE
Add webmention link

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,47 +1,47 @@
 import path from "path";
 
-/** site metadata */
+/** @type {object} global site metadata */
 export default {
-  /** site root URL */
+  /** @type {string} site root URL */
   url: "https://clhenrick.io/",
 
-  /** site domain name */
+  /** @type {string} site domain name */
   get domainName() {
     return path.basename(this.url);
   },
 
-  /** site title used through out various pages */
+  /** @type {string} site title used through out various pages */
   get title() {
     return this.domainName;
   },
 
-  /** banner image used for home page and default og meta tag in head */
+  /** @type {string} banner image used for home page and default og meta tag in head */
   get titleImage() {
     return path.join("img", "oakland-map-dark-1800w.webp");
   },
 
-  /** alt text for banner image */
+  /** @type {string} alt text for banner image */
   titleImageAlt:
     "A geographic map of the city of Oakland, California, centered on downtown. The map's extent spans the San Francisco Bay to the west, the cities of Berkeley and Emeryville to the north, the Oakland hills to the east, and the city of Alameda to the south. The map depicts the road networks and names of various cities and neighborhoods, predominantly in the East Bay area. It includes a topographic shaded relief rendering of the rugged Oakland hills.",
 
-  /** mime type of banner image */
+  /** @type {string} mime type of banner image */
   titleImageType: "image/webp",
 
-  /** open graph logo image */
+  /** @type {string} open graph logo image */
   get logoImage() {
     return path.join("favicon", "apple-touch-icon.png");
   },
 
-  /** site webmention.io URL */
+  /** @type {string} site webmention.io URL */
   get webmentionUrl() {
     return new URL(`${this.domainName}/webmention`, "https://webmention.io")
       .href;
   },
 
-  /** site language code */
+  /** @type {string} site language code */
   language: "en",
 
-  /** site description used in head meta tags and RSS */
+  /** @type {string} site description used in head meta tags and RSS */
   description:
     "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",
 
@@ -77,9 +77,9 @@ export default {
     ["Ko-Fi", "https://ko-fi.com/chrislhenrick"],
   ]),
 
-  /** light theme-color for head meta tag (used for styling browser UI when supported) */
+  /** @type {string} light theme-color for head meta tag (used for styling browser UI when supported) */
   metaThemeColorLight: "#0052a6",
 
-  /** dark theme-color for head meta tag (not honored by all browsers) */
+  /** @type {string} dark theme-color for head meta tag (not honored by all browsers) */
   metaThemeColorDark: "#00204d",
 };

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,36 +1,64 @@
 import path from "path";
 
+/** site metadata */
 export default {
+  /** site root URL */
   url: "https://clhenrick.io/",
+
+  /** site domain name */
   get domainName() {
     return path.basename(this.url);
   },
+
+  /** site title used through out various pages */
   get title() {
     return this.domainName;
   },
+
+  /** banner image used for home page and og meta tag in head */
   get titleImage() {
     return path.join("img", "oakland-map-dark-1800w.webp");
   },
+
+  /** alt text for home title image */
   titleImageAlt:
     "A geographic map of the city of Oakland, California, centered on downtown. The map's extent spans the San Francisco Bay to the west, the cities of Berkeley and Emeryville to the north, the Oakland hills to the east, and the city of Alameda to the south. The map depicts the road networks and names of various cities and neighborhoods, predominantly in the East Bay area. It includes a topographic shaded relief rendering of the rugged Oakland hills.",
+
+  /** mime type of title image */
   titleImageType: "image/webp",
+
+  /** used for open graph logo */
   get logoImage() {
     return path.join("favicon", "apple-touch-icon.png");
   },
+
+  /** site webmention.io URL */
   get webmentionUrl() {
     return new URL(`${this.domainName}/webmention`, "https://webmention.io")
       .href;
   },
+
+  /** site language code */
   language: "en",
+
+  /** site description used in head meta data and RSS */
   description:
     "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",
+
+  /** nodejs environment setting */
   environment: process.env.NODE_ENV,
+
+  /** site github repository URL */
   githubRepository: "https://github.com/clhenrick/clhenrick.io",
+
+  /** site author metadata */
   author: {
     name: "Chris Henrick",
     email: "chrishenrick@gmail.com",
     url: "https://clhenrick.io/about/",
   },
+
+  /** social media handles */
   socialHandles: new Map([
     ["Github", "@clhenrick"],
     ["Mastodon", "@clhenrick@indieweb.social"],
@@ -38,6 +66,8 @@ export default {
     ["LinkedIn", "@chrishenrick"],
     ["Ko-Fi", "@chrislhenrick"],
   ]),
+
+  /** social media URLs */
   socialLinks: new Map([
     ["GitHub", "https://github.com/clhenrick"],
     ["Mastodon", "https://indieweb.social/@clhenrick"],
@@ -45,6 +75,10 @@ export default {
     ["LinkedIn", "https://www.linkedin.com/in/chrishenrick/"],
     ["Ko-Fi", "https://ko-fi.com/chrislhenrick"],
   ]),
-  metaThemeColorDark: "#00204d",
+
+  /** light theme-color for head meta tag (used for styling browser UI when supported) */
   metaThemeColorLight: "#0052a6",
+
+  /** dark theme-color for head meta tag (not honored by all browsers) */
+  metaThemeColorDark: "#00204d",
 };

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -6,12 +6,11 @@ export default {
   titleImageType: "image/webp",
   logoImage: "favicon/apple-touch-icon.png",
   url: "https://clhenrick.io/",
-  getDomainName() {
+  get domainName() {
     return this.url.replaceAll("/", "").replace("https:", "");
   },
-  getWebmentionUrl() {
-    const domain = this.getDomainName();
-    return `https://webmention.io/${domain}/webmention`;
+  get webmentionUrl() {
+    return `https://webmention.io/${this.domainName}/webmention`;
   },
   language: "en",
   description:

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -6,6 +6,13 @@ export default {
   titleImageType: "image/webp",
   logoImage: "favicon/apple-touch-icon.png",
   url: "https://clhenrick.io/",
+  getDomainName() {
+    return this.url.replaceAll("/", "").replace("https:", "");
+  },
+  getWebmentionUrl() {
+    const domain = this.getDomainName();
+    return `https://webmention.io/${domain}/webmention`;
+  },
   language: "en",
   description:
     "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -1,16 +1,25 @@
+import path from "path";
+
 export default {
-  title: "clhenrick.io",
-  titleImage: "img/oakland-map-dark-1800w.webp",
+  url: "https://clhenrick.io/",
+  get domainName() {
+    return path.basename(this.url);
+  },
+  get title() {
+    return this.domainName;
+  },
+  get titleImage() {
+    return path.join("img", "oakland-map-dark-1800w.webp");
+  },
   titleImageAlt:
     "A geographic map of the city of Oakland, California, centered on downtown. The map's extent spans the San Francisco Bay to the west, the cities of Berkeley and Emeryville to the north, the Oakland hills to the east, and the city of Alameda to the south. The map depicts the road networks and names of various cities and neighborhoods, predominantly in the East Bay area. It includes a topographic shaded relief rendering of the rugged Oakland hills.",
   titleImageType: "image/webp",
-  logoImage: "favicon/apple-touch-icon.png",
-  url: "https://clhenrick.io/",
-  get domainName() {
-    return this.url.replaceAll("/", "").replace("https:", "");
+  get logoImage() {
+    return path.join("favicon", "apple-touch-icon.png");
   },
   get webmentionUrl() {
-    return `https://webmention.io/${this.domainName}/webmention`;
+    return new URL(`${this.domainName}/webmention`, "https://webmention.io")
+      .href;
   },
   language: "en",
   description:

--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -15,19 +15,19 @@ export default {
     return this.domainName;
   },
 
-  /** banner image used for home page and og meta tag in head */
+  /** banner image used for home page and default og meta tag in head */
   get titleImage() {
     return path.join("img", "oakland-map-dark-1800w.webp");
   },
 
-  /** alt text for home title image */
+  /** alt text for banner image */
   titleImageAlt:
     "A geographic map of the city of Oakland, California, centered on downtown. The map's extent spans the San Francisco Bay to the west, the cities of Berkeley and Emeryville to the north, the Oakland hills to the east, and the city of Alameda to the south. The map depicts the road networks and names of various cities and neighborhoods, predominantly in the East Bay area. It includes a topographic shaded relief rendering of the rugged Oakland hills.",
 
-  /** mime type of title image */
+  /** mime type of banner image */
   titleImageType: "image/webp",
 
-  /** used for open graph logo */
+  /** open graph logo image */
   get logoImage() {
     return path.join("favicon", "apple-touch-icon.png");
   },
@@ -41,24 +41,25 @@ export default {
   /** site language code */
   language: "en",
 
-  /** site description used in head meta data and RSS */
+  /** site description used in head meta tags and RSS */
   description:
     "The website, blog, and portfolio of Chris L Henrick, front-end web developer and design engineer.",
 
-  /** nodejs environment setting */
+  /** @type {"production" | "development"} nodejs env setting */
   environment: process.env.NODE_ENV,
 
   /** site github repository URL */
   githubRepository: "https://github.com/clhenrick/clhenrick.io",
 
-  /** site author metadata */
+  /** @type {{ name: string; email: string; url: string; }} site author metadata */
   author: {
     name: "Chris Henrick",
     email: "chrishenrick@gmail.com",
     url: "https://clhenrick.io/about/",
   },
 
-  /** social media handles */
+  /** @typedef {"Github" | "Mastodon" | "Observable" | "LinkedIn" | "Ko-Fi"} SocialHandles */
+  /** @type {Map<SocialHandles, string>} social media handles */
   socialHandles: new Map([
     ["Github", "@clhenrick"],
     ["Mastodon", "@clhenrick@indieweb.social"],
@@ -67,7 +68,7 @@ export default {
     ["Ko-Fi", "@chrislhenrick"],
   ]),
 
-  /** social media URLs */
+  /** @type {Map<SocialHandles, string>} social media URLs */
   socialLinks: new Map([
     ["GitHub", "https://github.com/clhenrick"],
     ["Mastodon", "https://indieweb.social/@clhenrick"],

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -51,7 +51,7 @@
   <meta name="generator" content="{{ eleventy.generator }}" />
 
   {# webmentions #}
-  <link rel="webmention" href="{{ metadata.getWebmentionUrl() }}" />
+  <link rel="webmention" href="{{ metadata.webmentionUrl }}" />
 
   {# RSS feeds #}
   <link

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -50,6 +50,9 @@
   {# Let's others know this site was created using 11ty #}
   <meta name="generator" content="{{ eleventy.generator }}" />
 
+  {# webmentions #}
+  <link rel="webmention" href="{{ metadata.getWebmentionUrl() }}" />
+
   {# RSS feeds #}
   <link
     rel="alternate"

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -50,7 +50,7 @@
   {# Let's others know this site was created using 11ty #}
   <meta name="generator" content="{{ eleventy.generator }}" />
 
-  {# webmentions #}
+  {# webmentions: https://indieweb.org/Webmention #}
   <link rel="webmention" href="{{ metadata.webmentionUrl }}" />
 
   {# RSS feeds #}


### PR DESCRIPTION
- adds a `<link>` in the site wide `<head>` to this site's `webmention.io` URL for enabling [webmentions](https://indieweb.org/Webmention)
- updates the global metadata object to include JS Doc types and getters for computed properties