### PR TITLE
update styles for inline <code> in blog posts

### DIFF
--- a/assets/css/pages/post.css
+++ b/assets/css/pages/post.css
@@ -64,3 +64,13 @@ p.post-teaser {
   font-style: italic;
   text-wrap: balance;
 }
+
+p > code {
+  /* HACK: custom font-size attempts to match non-mono font typeface but this may not work well for all system fonts */
+  font-size: 1.15rem;
+
+  /* NOTE: --color-syntax-2 is inherited from code.css */
+  background-color: var(--color-syntax-2);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-xxs) var(--spacing-xs);
+}


### PR DESCRIPTION
Adds the conventional `padding`, `background-color`, and `border-radius` properties to help make inline `<code>` formatted text stand out a bit more without standing out too much. Only applied to blog posts for the time being (since that's where these inline code appear, I think).

Dark:

<img width="881" alt="Screenshot 2025-01-26 at 9 12 36 PM" src="https://github.com/user-attachments/assets/9c6e5577-528e-4f39-9d74-0a844ba43fd6" />

Light:

<img width="899" alt="Screenshot 2025-01-26 at 9 12 54 PM" src="https://github.com/user-attachments/assets/67523304-88ab-4667-941a-eea3eff6569b" />
