### PR TITLE
replace usage of some <li> elements with <article>

### DIFF
--- a/_includes/components/projectCard.njk
+++ b/_includes/components/projectCard.njk
@@ -1,6 +1,6 @@
 {# Card component for use in work/index #}
 {% macro projectCard(project, thumb = "") %}
-  <li class="card">
+  <article class="card">
     <div class="img">
       {%- if thumb %}
         {% dataCascadeImage thumb.image.stats, "" %}
@@ -21,5 +21,5 @@
         </ul>
       {% endif %}
     </div>
-  </li>
+  </article>
 {% endmacro %}

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -9,9 +9,9 @@
 {# prettier-ignore-end #}
 {% endcss %}
 {%- set headingLevel = headingLevel if headingLevel else 2 %}
-<ol reversed class="postlist" role="list">
+<div class="postlist">
   {% for post in postslist | reverse %}
-    <li
+    <article
       class="postlist-item{% if post.url == url %}postlist-item-active{% endif %}"
     >
       {# prettier-ignore-start #}
@@ -36,6 +36,6 @@
       {%- if post.data.teaser -%}
         <p>{{ post.data.teaser }}</p>
       {%- endif %}
-    </li>
+    </article>
   {% endfor %}
-</ol>
+</div>

--- a/assets/css/components/posts-list.css
+++ b/assets/css/components/posts-list.css
@@ -1,16 +1,16 @@
-ol.postlist li {
+.postlist article {
   display: flex;
   flex-direction: column;
   margin-bottom: var(--spacing-xl);
 }
 
 /* postlist title, usually an h2 or h3 */
-ol.postlist li > *:first-child {
+.postlist article > *:first-child {
   margin-top: var(--spacing-xs);
   margin-bottom: var(--spacing-md);
   max-width: 34ch;
 }
 
-ol.postlist li div {
+.postlist article div {
   order: -1;
 }

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -13,50 +13,55 @@ eleventyNavigation:
 {% include "styles.njk" %}
 {% from "components/projectCard.njk" import projectCard %}
 
-<h1>Portfolio</h1>
+<section>
+  <h1>Portfolio</h1>
 
-<details open>
-  <summary>About</summary>
-  <p>{{ description }}</p>
-</details>
+  <details open>
+    <summary>About</summary>
+    <p>{{ description }}</p>
+  </details>
+</section>
 
-<details open data-id="project-filters-disclosure">
-  <summary id="filter-projects-title">Filter Projects</summary>
-  <p id="filter-projects-desc">
-    Projects are shown in reverse chronological order by default. Use these
-    buttons to view projects by a single category and/or shuffle the projects to
-    view them in a random order.
-  </p>
-  <div
-    role="group"
-    class="project-filters"
-    aria-labelledby="filter-projects-title"
-    aria-describedby="filter-projects-desc"
-  >
-    <button value="all" class="button filter" aria-pressed="true">all</button>
-    <button value="web" class="button filter" aria-pressed="false">
-      interactive
-    </button>
-    <button value="data-viz" class="button filter" aria-pressed="false">
-      data viz
-    </button>
-    <button value="cartography" class="button filter" aria-pressed="false">
-      cartography
-    </button>
-    <button class="button shuffle">shuffle!</button>
-  </div>
-</details>
+<section>
+  <details open data-id="project-filters-disclosure">
+    <summary id="filter-projects-title">Filter Projects</summary>
+    <p id="filter-projects-desc">
+      Projects are shown in reverse chronological order by default. Use these
+      buttons to view projects by a single category and/or shuffle the projects
+      to view them in a random order.
+    </p>
+    <div
+      role="group"
+      class="project-filters"
+      aria-labelledby="filter-projects-title"
+      aria-describedby="filter-projects-desc"
+    >
+      <button value="all" class="button filter" aria-pressed="true">all</button>
+      <button value="web" class="button filter" aria-pressed="false">
+        interactive
+      </button>
+      <button value="data-viz" class="button filter" aria-pressed="false">
+        data viz
+      </button>
+      <button value="cartography" class="button filter" aria-pressed="false">
+        cartography
+      </button>
+      <button class="button shuffle">shuffle!</button>
+    </div>
+  </details>
 
-<ul class="cards-container" role="list">
-  {% for project in work %}
-    {# NOTE: this uses global image thumbnail data and the dataCascadeImage shortcode  #}
-    {%- set basename = project.thumb | replace(".jpg", "") | replace(".jpeg", "") | replace(".png", "") %}
-    {%- set thumb = work_image_thumbnails[basename] %}
-    {{ projectCard(project, thumb) }}
-  {% endfor %}
-</ul>
+  <section class="cards-container" aria-labelledby="projects-label">
+    <span id="projects-label" hidden>Projects</span>
+    {% for project in work %}
+      {# NOTE: this uses global image thumbnail data and the dataCascadeImage shortcode  #}
+      {%- set basename = project.thumb | replace(".jpg", "") | replace(".jpeg", "") | replace(".png", "") %}
+      {%- set thumb = work_image_thumbnails[basename] %}
+      {{ projectCard(project, thumb) }}
+    {% endfor %}
+  </section>
 
-<div id="announce" class="visually-hidden" aria-live="polite"></div>
+  <div id="announce" class="visually-hidden" aria-live="polite"></div>
+</section>
 
 {%- set javascripts -%}
   work, disclosure-widgets


### PR DESCRIPTION
For places where complex lists are rendered that contain links to other pages, use the HTML `<article>` element instead of a `<li>` element:
- home page: latest blog post links
- blog/n/: blog post links
- blog/archive: blog post links
- work/index: project cards