### PR TITLE
wrap h1 text on home page

### DIFF
--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -82,9 +82,10 @@ main section h2 {
     3.253rem + 1.998vw,
     var(--title-max-font-size)
   );
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  font-weight: bold;
+  overflow-wrap: anywhere;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Addresses part of #121. Prevents h1 text from being cut off when there is not enough horizontal room