### PR TITLE
feat: obfuscate email address in contact page

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -78,6 +78,7 @@
     "GSAP",
     "Harasymiv",
     "heavyai",
+    "hella",
     "Higley",
     "horiz",
     "Hovhannisyan",

--- a/assets/css/pages/contact.css
+++ b/assets/css/pages/contact.css
@@ -58,3 +58,8 @@ button[type="submit"] {
 #s-h-p {
   display: none;
 }
+
+/* for email obfuscation (see 11ty shortcode in eleventy.config.js) */
+.email > span:nth-child(2) {
+  display: none;
+}

--- a/assets/css/pages/contact.css
+++ b/assets/css/pages/contact.css
@@ -59,7 +59,13 @@ button[type="submit"] {
   display: none;
 }
 
-/* for email obfuscation (see 11ty shortcode in eleventy.config.js) */
-.email > span:nth-child(2) {
-  display: none;
+.email {
+  > span {
+    color: var(--color-accent);
+  }
+
+  /* for email obfuscation (see 11ty shortcode in eleventy.config.js) */
+  span:nth-child(2) {
+    display: none;
+  }
 }

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -16,9 +16,9 @@ eleventyNavigation:
 
 <h1>{{ title }}</h1>
 
-<p>
-  You may contact me using the form on this page. You may also
-  <a href="mailto:{{ metadata.author.email }}">email me</a>.
+<p class="email">
+  You may contact me using the form on this page. You may also email me at
+  {% obfuscateEmail metadata.author.email %}.
 </p>
 
 <form

--- a/content/contact/index.njk
+++ b/content/contact/index.njk
@@ -18,7 +18,7 @@ eleventyNavigation:
 
 <p class="email">
   You may contact me using the form on this page. You may also email me at
-  {% obfuscateEmail metadata.author.email %}.
+  <span>{% obfuscateEmail metadata.author.email %}</span>.
 </p>
 
 <form

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -161,6 +161,14 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addFilter("isArray", (value) => Array.isArray(value));
 
+  /** obfuscates an email address by inserting a hidden HTML span element to throw off web scrapers to prevent spam */
+  eleventyConfig.addShortcode("obfuscateEmail", (value) => {
+    // NOTE: the second span is hidden via `display: none` in contact.css
+    return value
+      .replace(/@/, "<span>@</span>")
+      .replace(/\./, "<span>.hella</span>.");
+  });
+
   eleventyConfig.addPairedShortcode(
     "figure",
     (content, caption, className = "figure") => {


### PR DESCRIPTION
Using the CSS method from [spencer mortensen's guide on email obfuscation](https://spencermortensen.com/articles/email-obfuscation/#text-display).